### PR TITLE
Fix logo size and remove duplicate mobile menu

### DIFF
--- a/app/Home.module.css
+++ b/app/Home.module.css
@@ -32,7 +32,7 @@
 }
 
 .logo img {
-  height: 50px;
+  height: 70px;
   width: auto;
 }
 
@@ -87,6 +87,11 @@
   font-size: 1.5rem;
   color: var(--primary-blue);
   cursor: pointer;
+}
+
+/* Navigation for mobile menu */
+.mobileNav {
+  display: none;
 }
 
 /* Hero Section */
@@ -427,8 +432,24 @@
     padding: 1rem;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
   }
-  
+
   .nav.active {
+    display: flex;
+  }
+
+  .mobileNav {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: white;
+    flex-direction: column;
+    padding: 1rem;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  }
+
+  .mobileNav.active {
     display: flex;
   }
   

--- a/app/components/MobileMenu.js
+++ b/app/components/MobileMenu.js
@@ -15,7 +15,7 @@ export default function MobileMenu() {
       >
         ☰
       </button>
-      <nav className={`${styles.nav} ${isOpen ? styles.active : ''}`}>
+      <nav className={`${styles.mobileNav} ${isOpen ? styles.active : ''}`}>
         <a href="#servicios" onClick={() => setIsOpen(false)}>Servicios</a>
         <a href="#convenios" onClick={() => setIsOpen(false)}>Convenios</a>
         <a href="#contacto" onClick={() => setIsOpen(false)}>Contacto</a>

--- a/app/page.js
+++ b/app/page.js
@@ -159,7 +159,7 @@ export default function Home() {
       <header className={styles.header}>
         <div className={styles.headerContent}>
           <div className={styles.logo}>
-            <Image src="/logo-verasalud.png" alt="VeraSalud Logo" width={50} height={50} />
+            <Image src="/logo-verasalud.png" alt="VeraSalud Logo" width={80} height={80} />
             <div>
               <h1>VeraSalud</h1>
               <p>Medicina Interna & Ecografías</p>


### PR DESCRIPTION
## Summary
- enlarge the logo displayed in the header
- add a dedicated class for the mobile navigation menu
- hide mobile navigation on desktop to avoid duplicated links

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d5eb085d4833095d2e7bf833902ce