### PR TITLE
Add SEO-focused service pages

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -222,7 +222,11 @@ export default function Home() {
             </div>
 
             <div className={styles.serviceCard}>
-              <h3>Electrocardiograma Especializado</h3>
+              <h3>
+                <Link href="/servicios/electrocardiograma" prefetch={false}>
+                  Electrocardiograma Especializado
+                </Link>
+              </h3>
               <p>Electrocardiogramas con especialistas en cardiología. Detección temprana de arritmias y afecciones cardiacas. Equipos modernos y diagnóstico preciso en Cali.</p>
               <ul>
                 <li>Detección temprana precisa</li>
@@ -233,7 +237,11 @@ export default function Home() {
             </div>
 
             <div className={styles.serviceCard}>
-              <h3>Ecografías de Alta Resolución</h3>
+              <h3>
+                <Link href="/servicios/ecografias" prefetch={false}>
+                  Ecografías de Alta Resolución
+                </Link>
+              </h3>
               <p>Ecografías convencionales y Doppler con tecnología de alta resolución. Detecta afecciones antes de síntomas. Resultados inmediatos y estudios precisos en Cali.</p>
               <ul>
                 <li>Tecnología de alta resolución</li>

--- a/app/servicios/ecografias/abdominal/page.js
+++ b/app/servicios/ecografias/abdominal/page.js
@@ -1,0 +1,62 @@
+import Image from 'next/image'
+import ContactForm from '../../../components/ContactForm'
+import styles from '../../../Home.module.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Ecografía Abdominal en Cali | VeraSalud',
+  description: 'Ultrasonido abdominal para evaluar órganos internos y detectar patologías en VeraSalud.',
+  keywords: ['ecografia abdominal cali', 'ultrasonido de abdomen', 'imagen diagnostica cali'],
+  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/abdominal' },
+  openGraph: {
+    title: 'Ecografía Abdominal en Cali | VeraSalud',
+    description: 'Estudio ecográfico de abdomen con tecnología de alta resolución en Cali.',
+    url: 'https://verasalud.com/servicios/ecografias/abdominal',
+    images: [
+      { url: '/ecografia-abdominal.jpg', width: 1200, height: 630, alt: 'Equipo realizando ecografía abdominal en Cali' }
+    ],
+    locale: 'es_CO',
+    type: 'article'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ecografía Abdominal en VeraSalud',
+    description: 'Diagnóstico preciso de hígado, riñones y vesícula con ecografía abdominal.'
+  }
+}
+
+export default function EcografiaAbdominalPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalProcedure',
+    name: 'Ecografía Abdominal',
+    description: 'Procedimiento de imagen que permite visualizar hígado, vesícula, riñones y otros órganos abdominales.',
+    url: 'https://verasalud.com/servicios/ecografias/abdominal',
+    image: 'https://verasalud.com/ecografia-abdominal.jpg'
+  }
+
+  return (
+    <div className={styles.container}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <section className={styles.hero}>
+        <div className={styles.heroContent}>
+          <h1>Ecografía Abdominal</h1>
+          <p>La ecografía abdominal es un examen no invasivo que permite revisar tus órganos internos.</p>
+          <p>Se utiliza para diagnosticar afecciones del hígado, vesícula, riñones y páncreas, entre otros.</p>
+          <p>Durante el procedimiento se desliza un transductor sobre tu abdomen con un gel especial.</p>
+          <p>Ofrece resultados rápidos y no produce radiación, siendo seguro para la mayoría de pacientes.</p>
+          <p><strong>Agenda tu cita hoy mismo.</strong></p>
+        </div>
+        <Image src="/ecografia-abdominal.jpg" alt="Equipo realizando ecografía abdominal" width={800} height={500} />
+      </section>
+      <section className={styles.contact}>
+        <div className={styles.container}>
+          <ContactForm />
+          <p style={{ marginTop: '2rem' }}>
+            <Link href="/">Volver al inicio</Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/servicios/ecografias/doppler/page.js
+++ b/app/servicios/ecografias/doppler/page.js
@@ -1,0 +1,62 @@
+import Image from 'next/image'
+import ContactForm from '../../../components/ContactForm'
+import styles from '../../../Home.module.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Ecografía Doppler en Cali | VeraSalud',
+  description: 'Estudio Doppler para evaluar el flujo sanguíneo y detectar obstrucciones vasculares.',
+  keywords: ['ecografia doppler cali', 'doppler venoso', 'doppler arterial'],
+  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/doppler' },
+  openGraph: {
+    title: 'Ecografía Doppler en Cali | VeraSalud',
+    description: 'Procedimiento Doppler color para valorar venas y arterias con precisión.',
+    url: 'https://verasalud.com/servicios/ecografias/doppler',
+    images: [
+      { url: '/ecografia-doppler.jpg', width: 1200, height: 630, alt: 'Ecografía Doppler en VeraSalud' }
+    ],
+    locale: 'es_CO',
+    type: 'article'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ecografía Doppler en VeraSalud',
+    description: 'Diagnóstico de problemas circulatorios con ecografía Doppler de alta definición.'
+  }
+}
+
+export default function EcografiaDopplerPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalProcedure',
+    name: 'Ecografía Doppler',
+    description: 'Procedimiento que analiza el flujo sanguíneo en venas y arterias para detectar obstrucciones o reflujos.',
+    url: 'https://verasalud.com/servicios/ecografias/doppler',
+    image: 'https://verasalud.com/ecografia-doppler.jpg'
+  }
+
+  return (
+    <div className={styles.container}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <section className={styles.hero}>
+        <div className={styles.heroContent}>
+          <h1>Ecografía Doppler</h1>
+          <p>La ecografía Doppler permite estudiar el flujo de la sangre en venas y arterias.</p>
+          <p>Es fundamental para diagnosticar trombosis, varices o problemas en arterias carótidas.</p>
+          <p>Utiliza ultrasonido con efecto Doppler para medir la velocidad y dirección de la circulación.</p>
+          <p>Ayuda a planear tratamientos vasculares y a prevenir complicaciones.</p>
+          <p><strong>Agenda tu cita hoy mismo.</strong></p>
+        </div>
+        <Image src="/ecografia-doppler.jpg" alt="Aplicación de ecografía Doppler" width={800} height={500} />
+      </section>
+      <section className={styles.contact}>
+        <div className={styles.container}>
+          <ContactForm />
+          <p style={{ marginTop: '2rem' }}>
+            <Link href="/">Volver al inicio</Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/servicios/ecografias/hepatica/page.js
+++ b/app/servicios/ecografias/hepatica/page.js
@@ -1,0 +1,62 @@
+import Image from 'next/image'
+import ContactForm from '../../../components/ContactForm'
+import styles from '../../../Home.module.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Ecografía Hepática en Cali | VeraSalud',
+  description: 'Examen ecográfico para estudiar el hígado y diagnosticar enfermedades hepáticas.',
+  keywords: ['ecografia hepatica cali', 'ultrasonido de higado', 'diagnostico higado cali'],
+  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/hepatica' },
+  openGraph: {
+    title: 'Ecografía Hepática en Cali | VeraSalud',
+    description: 'Ecografía especializada para evaluar el hígado con imágenes de alta resolución.',
+    url: 'https://verasalud.com/servicios/ecografias/hepatica',
+    images: [
+      { url: '/ecografia-hepatica.jpg', width: 1200, height: 630, alt: 'Realizando ecografía hepática en VeraSalud' }
+    ],
+    locale: 'es_CO',
+    type: 'article'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ecografía Hepática en VeraSalud',
+    description: 'Diagnóstico preciso de enfermedades del hígado con ecografía hepática.'
+  }
+}
+
+export default function EcografiaHepaticaPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalProcedure',
+    name: 'Ecografía Hepática',
+    description: 'Procedimiento de imagen para revisar el hígado, detectar lesiones y evaluar su tamaño.',
+    url: 'https://verasalud.com/servicios/ecografias/hepatica',
+    image: 'https://verasalud.com/ecografia-hepatica.jpg'
+  }
+
+  return (
+    <div className={styles.container}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <section className={styles.hero}>
+        <div className={styles.heroContent}>
+          <h1>Ecografía Hepática</h1>
+          <p>La ecografía hepática permite observar la estructura del hígado de forma detallada.</p>
+          <p>Ayuda a diagnosticar hígado graso, quistes, tumores y otras patologías.</p>
+          <p>Es un examen rápido y cómodo que no implica radiación.</p>
+          <p>Los resultados orientan el tratamiento y control de enfermedades hepáticas.</p>
+          <p><strong>Agenda tu cita hoy mismo.</strong></p>
+        </div>
+        <Image src="/ecografia-hepatica.jpg" alt="Ecografía del hígado en realización" width={800} height={500} />
+      </section>
+      <section className={styles.contact}>
+        <div className={styles.container}>
+          <ContactForm />
+          <p style={{ marginTop: '2rem' }}>
+            <Link href="/">Volver al inicio</Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/servicios/ecografias/mama/page.js
+++ b/app/servicios/ecografias/mama/page.js
@@ -1,0 +1,62 @@
+import Image from 'next/image'
+import ContactForm from '../../../components/ContactForm'
+import styles from '../../../Home.module.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Ecografía de Mama en Cali | VeraSalud',
+  description: 'Estudio ecográfico de seno para la detección temprana de lesiones mamarias.',
+  keywords: ['ecografia de mama cali', 'ultrasonido mamario', 'deteccion cancer seno'],
+  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/mama' },
+  openGraph: {
+    title: 'Ecografía de Mama en Cali | VeraSalud',
+    description: 'Examen seguro y eficaz para evaluar el tejido mamario en mujeres de todas las edades.',
+    url: 'https://verasalud.com/servicios/ecografias/mama',
+    images: [
+      { url: '/ecografia-mama.jpg', width: 1200, height: 630, alt: 'Ecografía mamaria realizada en VeraSalud' }
+    ],
+    locale: 'es_CO',
+    type: 'article'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ecografía Mamaria en VeraSalud',
+    description: 'Diagnóstico temprano de lesiones de seno con ecografía de mama.'
+  }
+}
+
+export default function EcografiaMamaPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalProcedure',
+    name: 'Ecografía de Mama',
+    description: 'Procedimiento de imagen que ayuda a identificar quistes, nódulos y otras alteraciones en el tejido mamario.',
+    url: 'https://verasalud.com/servicios/ecografias/mama',
+    image: 'https://verasalud.com/ecografia-mama.jpg'
+  }
+
+  return (
+    <div className={styles.container}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <section className={styles.hero}>
+        <div className={styles.heroContent}>
+          <h1>Ecografía de Mama</h1>
+          <p>La ecografía de mama es un examen indoloro que ayuda a detectar masas o cambios en el seno.</p>
+          <p>Se recomienda como complemento a la mamografía y en mujeres jóvenes.</p>
+          <p>No usa radiación y permite una evaluación rápida y detallada.</p>
+          <p>Contribuye a un diagnóstico temprano y oportuno.</p>
+          <p><strong>Agenda tu cita hoy mismo.</strong></p>
+        </div>
+        <Image src="/ecografia-mama.jpg" alt="Realización de ecografía mamaria" width={800} height={500} />
+      </section>
+      <section className={styles.contact}>
+        <div className={styles.container}>
+          <ContactForm />
+          <p style={{ marginTop: '2rem' }}>
+            <Link href="/">Volver al inicio</Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/servicios/ecografias/obstetrica/page.js
+++ b/app/servicios/ecografias/obstetrica/page.js
@@ -1,0 +1,62 @@
+import Image from 'next/image'
+import ContactForm from '../../../components/ContactForm'
+import styles from '../../../Home.module.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Ecografía Obstétrica en Cali | VeraSalud',
+  description: 'Seguimiento del embarazo con ecografía obstétrica de alta resolución.',
+  keywords: ['ecografia obstetrica cali', 'ultrasonido embarazo', 'control prenatal cali'],
+  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/obstetrica' },
+  openGraph: {
+    title: 'Ecografía Obstétrica en Cali | VeraSalud',
+    description: 'Imágenes detalladas del bebé y la madre para un control prenatal seguro.',
+    url: 'https://verasalud.com/servicios/ecografias/obstetrica',
+    images: [
+      { url: '/ecografia-obstetrica.jpg', width: 1200, height: 630, alt: 'Ecografía obstétrica en VeraSalud' }
+    ],
+    locale: 'es_CO',
+    type: 'article'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ecografía Obstétrica en VeraSalud',
+    description: 'Control del desarrollo del bebé con ecografía obstétrica especializada.'
+  }
+}
+
+export default function EcografiaObstetricaPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalProcedure',
+    name: 'Ecografía Obstétrica',
+    description: 'Procedimiento de imagen para evaluar el desarrollo fetal y la salud materna durante el embarazo.',
+    url: 'https://verasalud.com/servicios/ecografias/obstetrica',
+    image: 'https://verasalud.com/ecografia-obstetrica.jpg'
+  }
+
+  return (
+    <div className={styles.container}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <section className={styles.hero}>
+        <div className={styles.heroContent}>
+          <h1>Ecografía Obstétrica</h1>
+          <p>La ecografía obstétrica permite observar al bebé y la placenta durante la gestación.</p>
+          <p>Ayuda a confirmar la edad gestacional y detectar posibles anomalías de forma temprana.</p>
+          <p>Es un examen seguro que utiliza ultrasonido sin radiación.</p>
+          <p>Contribuye a un control prenatal responsable y tranquilo.</p>
+          <p><strong>Agenda tu cita hoy mismo.</strong></p>
+        </div>
+        <Image src="/ecografia-obstetrica.jpg" alt="Ecografía obstétrica" width={800} height={500} />
+      </section>
+      <section className={styles.contact}>
+        <div className={styles.container}>
+          <ContactForm />
+          <p style={{ marginTop: '2rem' }}>
+            <Link href="/">Volver al inicio</Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/servicios/ecografias/osteomuscular/page.js
+++ b/app/servicios/ecografias/osteomuscular/page.js
@@ -1,0 +1,62 @@
+import Image from 'next/image'
+import ContactForm from '../../../components/ContactForm'
+import styles from '../../../Home.module.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Ecografía Osteomuscular en Cali | VeraSalud',
+  description: 'Ultrasonido especializado para evaluar músculos, tendones y articulaciones.',
+  keywords: ['ecografia osteomuscular cali', 'ultrasonido musculos', 'ecografia de tendones'],
+  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/osteomuscular' },
+  openGraph: {
+    title: 'Ecografía Osteomuscular en Cali | VeraSalud',
+    description: 'Diagnóstico de lesiones deportivas y trastornos músculo-esqueléticos mediante ecografía.',
+    url: 'https://verasalud.com/servicios/ecografias/osteomuscular',
+    images: [
+      { url: '/ecografia-osteomuscular.jpg', width: 1200, height: 630, alt: 'Ecografía osteomuscular en VeraSalud' }
+    ],
+    locale: 'es_CO',
+    type: 'article'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ecografía Osteomuscular en VeraSalud',
+    description: 'Valoración precisa de tendones y articulaciones con ecografía osteomuscular.'
+  }
+}
+
+export default function EcografiaOsteomuscularPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalProcedure',
+    name: 'Ecografía Osteomuscular',
+    description: 'Procedimiento de imagen para analizar lesiones en músculos, tendones y ligamentos.',
+    url: 'https://verasalud.com/servicios/ecografias/osteomuscular',
+    image: 'https://verasalud.com/ecografia-osteomuscular.jpg'
+  }
+
+  return (
+    <div className={styles.container}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <section className={styles.hero}>
+        <div className={styles.heroContent}>
+          <h1>Ecografía Osteomuscular</h1>
+          <p>La ecografía osteomuscular permite observar en tiempo real músculos y articulaciones.</p>
+          <p>Se utiliza en lesiones deportivas y dolores crónicos para planear el tratamiento adecuado.</p>
+          <p>Es un examen dinámico y sin radiación que brinda información detallada del área afectada.</p>
+          <p>Ayuda a una recuperación más rápida y precisa.</p>
+          <p><strong>Agenda tu cita hoy mismo.</strong></p>
+        </div>
+        <Image src="/ecografia-osteomuscular.jpg" alt="Ecografía de músculos y articulaciones" width={800} height={500} />
+      </section>
+      <section className={styles.contact}>
+        <div className={styles.container}>
+          <ContactForm />
+          <p style={{ marginTop: '2rem' }}>
+            <Link href="/">Volver al inicio</Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/servicios/ecografias/pelvica/page.js
+++ b/app/servicios/ecografias/pelvica/page.js
@@ -1,0 +1,62 @@
+import Image from 'next/image'
+import ContactForm from '../../../components/ContactForm'
+import styles from '../../../Home.module.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Ecografía Pélvica en Cali | VeraSalud',
+  description: 'Evaluación ecográfica de útero y ovarios con tecnología de alta resolución.',
+  keywords: ['ecografia pelvica cali', 'ultrasonido transvaginal', 'ginecologia cali'],
+  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/pelvica' },
+  openGraph: {
+    title: 'Ecografía Pélvica en Cali | VeraSalud',
+    description: 'Diagnóstico de patologías ginecológicas mediante ecografía transvaginal o suprapúbica.',
+    url: 'https://verasalud.com/servicios/ecografias/pelvica',
+    images: [
+      { url: '/ecografia-pelvica.jpg', width: 1200, height: 630, alt: 'Ecografía pélvica en VeraSalud' }
+    ],
+    locale: 'es_CO',
+    type: 'article'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Ecografía Pélvica en VeraSalud',
+    description: 'Control y evaluación ginecológica con ecografía pélvica de alta resolución.'
+  }
+}
+
+export default function EcografiaPelvicaPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalProcedure',
+    name: 'Ecografía Pélvica',
+    description: 'Procedimiento ecográfico para revisar útero, ovarios y otras estructuras pélvicas.',
+    url: 'https://verasalud.com/servicios/ecografias/pelvica',
+    image: 'https://verasalud.com/ecografia-pelvica.jpg'
+  }
+
+  return (
+    <div className={styles.container}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <section className={styles.hero}>
+        <div className={styles.heroContent}>
+          <h1>Ecografía Pélvica</h1>
+          <p>La ecografía pélvica permite evaluar el útero, los ovarios y la vejiga.</p>
+          <p>Se realiza de forma transvaginal o suprapúbica según tu caso.</p>
+          <p>Ayuda a diagnosticar quistes, miomas y causas de dolor pélvico.</p>
+          <p>Es un examen rápido que facilita el seguimiento de tratamientos ginecológicos.</p>
+          <p><strong>Agenda tu cita hoy mismo.</strong></p>
+        </div>
+        <Image src="/ecografia-pelvica.jpg" alt="Procedimiento de ecografía pélvica" width={800} height={500} />
+      </section>
+      <section className={styles.contact}>
+        <div className={styles.container}>
+          <ContactForm />
+          <p style={{ marginTop: '2rem' }}>
+            <Link href="/">Volver al inicio</Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/servicios/electrocardiograma/page.js
+++ b/app/servicios/electrocardiograma/page.js
@@ -1,0 +1,67 @@
+import Image from 'next/image'
+import ContactForm from '../../components/ContactForm'
+import styles from '../../Home.module.css'
+import Link from 'next/link'
+
+export const metadata = {
+  title: 'Electrocardiograma en Cali | VeraSalud',
+  description: 'Examen ECG para evaluar la actividad eléctrica del corazón en VeraSalud Cali.',
+  keywords: ['electrocardiograma cali', 'ecg en cali', 'diagnóstico cardiaco'],
+  alternates: { canonical: 'https://verasalud.com/servicios/electrocardiograma' },
+  openGraph: {
+    title: 'Electrocardiograma en Cali | VeraSalud',
+    description: 'Electrocardiogramas precisos para detectar arritmias y otras afecciones cardiacas.',
+    url: 'https://verasalud.com/servicios/electrocardiograma',
+    images: [
+      {
+        url: '/electrocardiograma.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'Paciente realizándose un electrocardiograma en VeraSalud'
+      }
+    ],
+    locale: 'es_CO',
+    type: 'article'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Electrocardiograma en Cali',
+    description: 'Realiza tu electrocardiograma con especialistas en VeraSalud Cali.'
+  }
+}
+
+export default function ElectrocardiogramaPage() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'MedicalTest',
+    name: 'Electrocardiograma',
+    description: 'Prueba que registra la actividad eléctrica del corazón para detectar arritmias y otras alteraciones.',
+    url: 'https://verasalud.com/servicios/electrocardiograma',
+    image: 'https://verasalud.com/electrocardiograma.jpg'
+  }
+
+  return (
+    <div className={styles.container}>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <section className={styles.hero}>
+        <div className={styles.heroContent}>
+          <h1>Electrocardiograma</h1>
+          <p>El electrocardiograma (ECG) es un examen indoloro que mide la actividad eléctrica del corazón.</p>
+          <p>Sirve para diagnosticar arritmias, evaluar el ritmo cardiaco y controlar tratamientos.</p>
+          <p>Durante la prueba se colocan pequeños electrodos sobre tu pecho y extremidades. El procedimiento es rápido y seguro.</p>
+          <p>Entre sus beneficios están la detección temprana de problemas cardiacos y la orientación de terapias adecuadas.</p>
+          <p><strong>Agenda tu cita hoy mismo.</strong></p>
+        </div>
+        <Image src="/electrocardiograma.jpg" alt="Paciente realizándose un electrocardiograma" width={800} height={500} />
+      </section>
+      <section className={styles.contact}>
+        <div className={styles.container}>
+          <ContactForm />
+          <p style={{ marginTop: '2rem' }}>
+            <Link href="/">Volver al inicio</Link>
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/servicios/electrocardiograma` page with structured data
- add ultrasound pages under `/servicios/ecografias`
- link service titles on home page to new routes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68857285e2dc8330a5a6dbc90a2d4c7d