### PR TITLE
Responsive logo sizing

### DIFF
--- a/app/Home.module.css
+++ b/app/Home.module.css
@@ -32,8 +32,20 @@
 }
 
 .logo img {
-  height: 100px;
   width: auto;
+}
+
+/* Tamaño del logo en cabecera */
+.logoHeader {
+  width: 150px;
+  height: 150px;
+}
+
+@media (max-width: 768px) {
+  .logoHeader {
+    width: 100px;
+    height: 100px;
+  }
 }
 
 .logo h1 {

--- a/app/page.js
+++ b/app/page.js
@@ -159,7 +159,13 @@ export default function Home() {
       <header className={styles.header}>
         <div className={styles.headerContent}>
           <div className={styles.logo}>
-            <Image src="/logo-verasalud.png" alt="VeraSalud Logo" width={100} height={100} />
+            <Image
+              src="/logo-verasalud.png"
+              alt="VeraSalud Logo"
+              width={150}
+              height={150}
+              className={styles.logoHeader}
+            />
             <div>
               <h1>VeraSalud</h1>
               <p>Medicina Interna & Ecografías</p>


### PR DESCRIPTION
## Summary
- adjust logo `Image` component for desktop and mobile
- add `.logoHeader` style for responsive header logo size

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688574689390833090a0eeb197485395