### PR TITLE
Improve accessibility semantics

### DIFF
--- a/app/components/ContactForm.js
+++ b/app/components/ContactForm.js
@@ -12,16 +12,26 @@ export default function ContactForm() {
     <div className={styles.contactForm}>
       <h3>Agenda tu Cita Médica</h3>
       <form onSubmit={handleSubmit}>
-        <input type="text" placeholder="Nombre completo" required />
-        <input type="email" placeholder="Email" required />
-        <input type="tel" placeholder="Teléfono" required />
-        <select required>
+        <label htmlFor="name">Nombre completo</label>
+        <input id="name" type="text" placeholder="Nombre completo" required />
+
+        <label htmlFor="email">Email</label>
+        <input id="email" type="email" placeholder="Email" required />
+
+        <label htmlFor="phone">Teléfono</label>
+        <input id="phone" type="tel" placeholder="Teléfono" required />
+
+        <label htmlFor="service">Servicio</label>
+        <select id="service" required>
           <option value="">Selecciona el servicio</option>
           <option value="medicina-interna">Medicina Interna</option>
           <option value="electrocardiograma">Electrocardiograma</option>
           <option value="ecografias">Ecografías</option>
         </select>
-        <textarea placeholder="Describe tu consulta médica" rows="4" required></textarea>
+
+        <label htmlFor="message">Describe tu consulta médica</label>
+        <textarea id="message" placeholder="Describe tu consulta médica" rows="4" required></textarea>
+
         <button type="submit" className={styles.btnPrimary}>Solicitar Cita</button>
       </form>
     </div>

--- a/app/medicina-interna/page.js
+++ b/app/medicina-interna/page.js
@@ -10,7 +10,7 @@ export const metadata = {
 
 export default function MedicinaInternaPage() {
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <section className={styles.hero}>
         <div className={styles.heroContent}>
           <h1>Consulta de Medicina Interna</h1>
@@ -40,6 +40,6 @@ export default function MedicinaInternaPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/page.js
+++ b/app/page.js
@@ -188,6 +188,8 @@ export default function Home() {
         </div>
       </header>
 
+      <main>
+
       {/* Hero Section */}
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -330,6 +332,9 @@ export default function Home() {
       </section>
 
       {/* Footer con Redes Sociales */}
+</main>
+
+
       <footer className={styles.footer}>
         <div className={styles.container}>
           <div className={styles.footerContent}>

--- a/app/servicios/ecografias/abdominal/page.js
+++ b/app/servicios/ecografias/abdominal/page.js
@@ -36,7 +36,7 @@ export default function EcografiaAbdominalPage() {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -115,6 +115,6 @@ export default function EcografiaAbdominalPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/servicios/ecografias/doppler/page.js
+++ b/app/servicios/ecografias/doppler/page.js
@@ -36,7 +36,7 @@ export default function EcografiaDopplerPage() {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -57,6 +57,6 @@ export default function EcografiaDopplerPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/servicios/ecografias/hepatica/page.js
+++ b/app/servicios/ecografias/hepatica/page.js
@@ -36,7 +36,7 @@ export default function EcografiaHepaticaPage() {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -127,6 +127,6 @@ export default function EcografiaHepaticaPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/servicios/ecografias/mama/page.js
+++ b/app/servicios/ecografias/mama/page.js
@@ -36,7 +36,7 @@ export default function EcografiaMamaPage() {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -120,6 +120,6 @@ export default function EcografiaMamaPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/servicios/ecografias/obstetrica/page.js
+++ b/app/servicios/ecografias/obstetrica/page.js
@@ -36,7 +36,7 @@ export default function EcografiaObstetricaPage() {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -129,6 +129,6 @@ export default function EcografiaObstetricaPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/servicios/ecografias/osteomuscular/page.js
+++ b/app/servicios/ecografias/osteomuscular/page.js
@@ -36,7 +36,7 @@ export default function EcografiaOsteomuscularPage() {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -129,6 +129,6 @@ export default function EcografiaOsteomuscularPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/servicios/ecografias/pelvica/page.js
+++ b/app/servicios/ecografias/pelvica/page.js
@@ -36,7 +36,7 @@ export default function EcografiaPelvicaPage() {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -129,6 +129,6 @@ export default function EcografiaPelvicaPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/servicios/electrocardiograma/page.js
+++ b/app/servicios/electrocardiograma/page.js
@@ -41,7 +41,7 @@ export default function ElectrocardiogramaPage() {
   }
 
   return (
-    <div className={styles.container}>
+    <main className={styles.container}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>
@@ -109,6 +109,6 @@ export default function ElectrocardiogramaPage() {
           </p>
         </div>
       </section>
-    </div>
+    </main>
   )
 }


### PR DESCRIPTION
## Summary
- add semantic `<main>` wrapper on pages
- provide labels for contact form fields

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68858d3fd45083309c753dfa9a11e8f7