### PR TITLE
Fix sitemap ecografias routes

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -38,10 +38,59 @@
   </url>
 
   <url>
-    <loc>https://verasalud.com/ecografias</loc>
+    <loc>https://verasalud.com/servicios/ecografias</loc>
     <lastmod>2024-01-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://verasalud.com/servicios/ecografias/abdominal</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://verasalud.com/servicios/ecografias/doppler</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://verasalud.com/servicios/ecografias/hepatica</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://verasalud.com/servicios/ecografias/mama</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://verasalud.com/servicios/ecografias/obstetrica</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://verasalud.com/servicios/ecografias/osteomuscular</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://verasalud.com/servicios/ecografias/pelvica</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <url>


### PR DESCRIPTION
## Summary
- update `/ecografias` URL to `/servicios/ecografias`
- list child ecografías pages in sitemap

## Testing
- `npm run lint`
- `npm run build`
- `xmllint --noout public/sitemap.xml`


------
https://chatgpt.com/codex/tasks/task_e_688612dc49ac8330967c1e24082b5c22