### PR TITLE
Add ultrasound sublinks on home page

### DIFF
--- a/app/Home.module.css
+++ b/app/Home.module.css
@@ -262,6 +262,34 @@
   font-weight: bold;
 }
 
+/* Lista de enlaces de ecografías */
+.ecografiaLinks {
+  margin-top: 1rem;
+}
+
+.ecografiaLinks ul {
+  list-style: disc;
+  padding-left: 1.5rem;
+}
+
+.ecografiaLinks li {
+  padding: 0.25rem 0;
+  position: static;
+}
+
+.ecografiaLinks li::before {
+  content: none;
+}
+
+.ecografiaLinks a {
+  color: var(--primary-cyan);
+  text-decoration: none;
+}
+
+.ecografiaLinks a:hover {
+  text-decoration: underline;
+}
+
 /* Convenios Section */
 .convenios {
   padding: 4rem 0;

--- a/app/page.js
+++ b/app/page.js
@@ -257,6 +257,46 @@ export default function Home() {
                 <li>Ecografías Doppler especializadas</li>
                 <li>Sin listas de espera</li>
               </ul>
+              <div className={styles.ecografiaLinks}>
+                <h4>Tipos de Ecografías</h4>
+                <ul>
+                  <li>
+                    <Link href="/servicios/ecografias/abdominal" prefetch={false}>
+                      Abdominal
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/servicios/ecografias/doppler" prefetch={false}>
+                      Doppler
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/servicios/ecografias/hepatica" prefetch={false}>
+                      Hepática
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/servicios/ecografias/mama" prefetch={false}>
+                      Mamaria
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/servicios/ecografias/osteomuscular" prefetch={false}>
+                      Osteomuscular
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/servicios/ecografias/pelvica" prefetch={false}>
+                      Pélvica
+                    </Link>
+                  </li>
+                  <li>
+                    <Link href="/servicios/ecografias/obstetrica" prefetch={false}>
+                      Obstétrica
+                    </Link>
+                  </li>
+                </ul>
+              </div>
             </div>
 
           </div>


### PR DESCRIPTION
## Summary
- list detailed ultrasound types on home page
- style new ultrasound link list

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688616a752f88330be6975003a7cc1d9