### PR TITLE
Remove duplicate image from electrocardiograma page

### DIFF
--- a/app/servicios/electrocardiograma/page.js
+++ b/app/servicios/electrocardiograma/page.js
@@ -93,14 +93,6 @@ export default function ElectrocardiogramaPage() {
             <strong>Agende su cita con resultados confiables y sin demoras.</strong>
           </p>
         </div>
-        <Image
-          src="/electrocardiograma.jpg"
-          alt="Paciente realizándose un electrocardiograma"
-          width={800}
-          height={500}
-          sizes="(max-width: 768px) 100vw, 800px"
-          priority
-        />
       </section>
       <section className={styles.contact}>
         <div className={styles.container}>


### PR DESCRIPTION
## Summary
- delete unused `<Image>` tag from electrocardiograma service page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887b520922883308d6120c7100b6c57