### PR TITLE
Fix dark mode visibility

### DIFF
--- a/app/Home.module.css
+++ b/app/Home.module.css
@@ -202,6 +202,7 @@
 .services {
   padding: 4rem 0;
   background-color: var(--gray-light);
+  color: #1a1a1a;
 }
 
 .services h2 {
@@ -220,6 +221,7 @@
 
 .serviceCard {
   background: white;
+  color: #1a1a1a;
   padding: 2rem;
   border-radius: 10px;
   box-shadow: 0 2px 10px rgba(0,0,0,0.1);
@@ -294,6 +296,7 @@
 .convenios {
   padding: 4rem 0;
   background-color: white;
+  color: #1a1a1a;
 }
 
 .convenios h2 {
@@ -320,6 +323,7 @@
 
 .convenioCard {
   background: var(--gray-light);
+  color: #1a1a1a;
   padding: 2rem;
   border-radius: 10px;
   border: 2px solid var(--primary-cyan);
@@ -334,6 +338,7 @@
 .team {
   padding: 2rem 0;
   background-color: white;
+  color: #1a1a1a;
 }
 
 .teamPhoto {
@@ -347,6 +352,7 @@
 .contact {
   padding: 4rem 0;
   background-color: var(--gray-light);
+  color: #1a1a1a;
 }
 
 .contact h2 {

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,8 @@
 :root {
+  color-scheme: only light;
+  background-color: #ffffff;
+  color: #1a1a1a;
+
   --background: #ffffff;
   --foreground: #171717;
 
@@ -12,17 +16,6 @@
   --gray-dark: #343a40;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-
-    /* Opcional: colores adaptados a modo oscuro */
-    --primary-blue: #1a2b56;
-    --primary-pink: #d42d7f;
-    --primary-cyan: #32aabb;
-  }
-}
 
 html,
 body {
@@ -49,8 +42,8 @@ a {
   text-decoration: none;
 }
 
-@media (prefers-color-scheme: dark) {
-  html {
-    color-scheme: dark;
-  }
+.dark-fix {
+  background-color: #ffffff !important;
+  color: #1a1a1a !important;
 }
+

--- a/app/medicina-interna/page.js
+++ b/app/medicina-interna/page.js
@@ -11,7 +11,7 @@ export const metadata = {
 
 export default function MedicinaInternaPage() {
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <section className={styles.hero}>
         <div className={styles.heroContent}>
           <h1>Consulta de Medicina Interna</h1>

--- a/app/page.js
+++ b/app/page.js
@@ -144,7 +144,7 @@ const jsonLdLocalBusiness = {
 
 export default function Home() {
   return (
-    <div className={styles.container}>
+    <div className={`${styles.container} dark-fix`}>
       {/* Datos estructurados */}
       <script
         type="application/ld+json"

--- a/app/servicios/ecografias/abdominal/page.js
+++ b/app/servicios/ecografias/abdominal/page.js
@@ -36,7 +36,7 @@ export default function EcografiaAbdominalPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/servicios/ecografias/doppler/page.js
+++ b/app/servicios/ecografias/doppler/page.js
@@ -36,7 +36,7 @@ export default function EcografiaDopplerPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/servicios/ecografias/hepatica/page.js
+++ b/app/servicios/ecografias/hepatica/page.js
@@ -36,7 +36,7 @@ export default function EcografiaHepaticaPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/servicios/ecografias/mama/page.js
+++ b/app/servicios/ecografias/mama/page.js
@@ -36,7 +36,7 @@ export default function EcografiaMamaPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/servicios/ecografias/obstetrica/page.js
+++ b/app/servicios/ecografias/obstetrica/page.js
@@ -36,7 +36,7 @@ export default function EcografiaObstetricaPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/servicios/ecografias/osteomuscular/page.js
+++ b/app/servicios/ecografias/osteomuscular/page.js
@@ -36,7 +36,7 @@ export default function EcografiaOsteomuscularPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/servicios/ecografias/page.js
+++ b/app/servicios/ecografias/page.js
@@ -36,7 +36,7 @@ export default function EcografiasPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/app/servicios/ecografias/pelvica/page.js
+++ b/app/servicios/ecografias/pelvica/page.js
@@ -36,7 +36,7 @@ export default function EcografiaPelvicaPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <section className={styles.hero}>
         <div className={styles.heroContent}>

--- a/app/servicios/electrocardiograma/page.js
+++ b/app/servicios/electrocardiograma/page.js
@@ -43,7 +43,7 @@ export default function ElectrocardiogramaPage() {
   }
 
   return (
-    <main className={styles.container}>
+    <main className={`${styles.container} dark-fix`}>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}


### PR DESCRIPTION
## Summary
- enforce global light color scheme
- add `.dark-fix` helper class
- ensure cards and sections use consistent colors
- force page containers to remain light

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b5e69e32c83309d29ee9d4ab28d0a