### PR TITLE
feat: update favicon to official logo

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -129,10 +129,7 @@ export default function RootLayout({ children }) {
         <meta name="geo.position" content="3.4516;-76.5320" />
         <meta name="ICBM" content="3.4516, -76.5320" />
 
-        <link rel="icon" href="/favicon.ico" />
-        <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-        <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
-        <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+        <link rel="icon" href="/logo-verasalud.png" />
         <link rel="manifest" href="/site.webmanifest" />
         <meta name="theme-color" content="#21396f" />
         


### PR DESCRIPTION
## Summary
- replace old favicon links with VeraSalud logo

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbcc909748330bec662d91e2eea93