### PR TITLE
Improve hero image loading and flag oversized assets

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -76,6 +76,7 @@ export default function RootLayout({ children }) {
     name: 'VeraSalud',
     description: 'Centro médico especializado en medicina interna y ecografías de alta resolución',
     url: 'https://verasalud.com',
+    // TODO: Optimizar el logo a formato .webp
     logo: "/logo-verasalud.png",
     telephone: '+57-602-394-2289',
     address: {
@@ -129,6 +130,7 @@ export default function RootLayout({ children }) {
         <meta name="geo.position" content="3.4516;-76.5320" />
         <meta name="ICBM" content="3.4516, -76.5320" />
 
+        {/* TODO: Usar un favicon optimizado en formato .webp */}
         <link rel="icon" href="/logo-verasalud.png" />
         <link rel="manifest" href="/site.webmanifest" />
         <meta name="theme-color" content="#21396f" />

--- a/app/medicina-interna/page.js
+++ b/app/medicina-interna/page.js
@@ -21,12 +21,13 @@ export default function MedicinaInternaPage() {
       </section>
 
       <figure style={{ marginTop: '2rem', marginBottom: '2rem' }}>
+        {/* TODO: Optimizar esta imagen a formato .webp */}
         <Image
           src="/doctor-gustavo-garcia-verasalud.jpg"
           alt="Dr. Gustavo García, médico internista en Cali – especialista en diagnóstico y salud integral en VeraSalud"
           width={1200}
           height={800}
-          sizes="(max-width: 768px) 100vw, 800px"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           placeholder="blur"
           blurDataURL="/doctor-gustavo-garcia-verasalud.jpg"
           priority

--- a/app/page.js
+++ b/app/page.js
@@ -113,6 +113,7 @@ const jsonLdLocalBusiness = {
   "@context": "https://schema.org",
   "@type": "LocalBusiness",
   "name": "VeraSalud",
+  // TODO: Reemplazar por versión .webp optimizada del logo
   "image": "https://verasalud.com/logo-verasalud.png",
   "description": "Medicina Interna y Ecografías de Alta Resolución sin filas ni demoras. Médicos especialistas de la Universidad del Valle en Cali, Colombia.",
   "url": "https://verasalud.com",
@@ -159,6 +160,7 @@ export default function Home() {
       <header className={styles.header}>
         <div className={styles.headerContent}>
           <div className={styles.logo}>
+            {/* TODO: Optimizar el logo a formato .webp */}
             <Image
               src="/logo-verasalud.png"
               alt="VeraSalud Logo"
@@ -205,6 +207,16 @@ export default function Home() {
           <div className={styles.trustIndicators}>
             <p>✓ Médicos Universidad del Valle  ✓ Sin Demoras  ✓ Alta Tecnología</p>
           </div>
+          {/* TODO: Optimizar esta imagen a formato .webp */}
+          <Image
+            src="/equipo-medico.jpg"
+            alt="Equipo médico de VeraSalud"
+            width={1200}
+            height={600}
+            priority
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+            className={styles.teamPhoto}
+          />
         </div>
       </section>
 
@@ -322,21 +334,6 @@ export default function Home() {
               </div>
             </div>
           </div>
-        </div>
-      </section>
-
-      {/* Team Photo Section - Preparado para imagen */}
-      <section className={styles.team}>
-        <div className={styles.container}>
-          <Image
-            src="/equipo-medico.jpg"
-            alt="Equipo médico de VeraSalud"
-            width={1200}
-            height={600}
-            className={styles.teamPhoto}
-            loading="lazy"
-            sizes="(max-width: 768px) 100vw, 1200px"
-          />
         </div>
       </section>
 

--- a/app/servicios/ecografias/page.js
+++ b/app/servicios/ecografias/page.js
@@ -84,12 +84,13 @@ export default function EcografiasPage() {
           </p>
           <p><strong>Agenda tu cita hoy mismo.</strong></p>
         </div>
+        {/* TODO: Optimizar esta imagen a formato .webp */}
         <Image
           src="/equipo-medico.jpg"
           alt="Equipo médico realizando ecografía"
           width={800}
           height={500}
-          sizes="(max-width: 768px) 100vw, 800px"
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
           priority
         />
       </section>


### PR DESCRIPTION
## Summary
- use Next.js Image for landing hero with explicit sizing and priority
- flag heavy JPG/PNG assets for future WebP optimization across pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688fbe5cb4288330b5cc675aae689903