### PR TITLE
feat: send contact form data via email

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,19 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/pages/building-your-application/deploying) for more details.
+
+## Contact Form Configuration
+
+The contact form sends submitted data to **verasaludcali@gmail.com** and **info@verasalud.com** using SMTP credentials defined in `.env.local`:
+
+```
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+SMTP_SECURE=true
+SMTP_USER=usuario
+SMTP_PASS=contraseña
+# Opcional
+SMTP_FROM="VeraSalud <no-reply@verasalud.com>"
+```
+
+Make sure these variables are set before running `npm run build` or `npm start`.

--- a/app/Home.module.css
+++ b/app/Home.module.css
@@ -451,6 +451,16 @@
   border-color: var(--primary-cyan);
 }
 
+.contactForm .successMessage {
+  color: var(--primary-blue);
+  margin-top: 1rem;
+}
+
+.contactForm .errorMessage {
+  color: var(--primary-pink);
+  margin-top: 1rem;
+}
+
 /* Footer */
 .footer {
   background-color: var(--primary-blue);

--- a/app/api/contact/route.js
+++ b/app/api/contact/route.js
@@ -1,0 +1,43 @@
+import nodemailer from 'nodemailer'
+
+export async function POST(req) {
+  const { name, email, phone, service, message } = await req.json()
+
+  if (!name || !email || !phone || !service || !message) {
+    return new Response(JSON.stringify({ error: 'Missing fields' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+
+  try {
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 465,
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    })
+
+    await transporter.sendMail({
+      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      to: ['verasaludcali@gmail.com', 'info@verasalud.com'],
+      replyTo: email,
+      subject: `Nuevo mensaje de ${name}`,
+      text: `Nombre: ${name}\nEmail: ${email}\nTeléfono: ${phone}\nServicio: ${service}\nMensaje: ${message}`,
+    })
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    console.error(err)
+    return new Response(JSON.stringify({ error: 'Error sending message' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  }
+}

--- a/app/components/ContactForm.js
+++ b/app/components/ContactForm.js
@@ -1,11 +1,38 @@
 'use client'
 
+import { useState } from 'react'
 import styles from '../Home.module.css'
 
 export default function ContactForm() {
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    alert('Formulario enviado. Nos contactaremos contigo pronto.');
+  const [status, setStatus] = useState(null)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const form = e.target
+    const data = {
+      name: form.name.value,
+      email: form.email.value,
+      phone: form.phone.value,
+      service: form.service.value,
+      message: form.message.value,
+    }
+
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+
+      if (res.ok) {
+        setStatus('success')
+        form.reset()
+      } else {
+        setStatus('error')
+      }
+    } catch (error) {
+      setStatus('error')
+    }
   }
 
   return (
@@ -13,16 +40,16 @@ export default function ContactForm() {
       <h3>Agenda tu Cita Médica</h3>
       <form onSubmit={handleSubmit}>
         <label htmlFor="name">Nombre completo</label>
-        <input id="name" type="text" placeholder="Nombre completo" required />
+        <input id="name" name="name" type="text" placeholder="Nombre completo" required />
 
         <label htmlFor="email">Email</label>
-        <input id="email" type="email" placeholder="Email" required />
+        <input id="email" name="email" type="email" placeholder="Email" required />
 
         <label htmlFor="phone">Teléfono</label>
-        <input id="phone" type="tel" placeholder="Teléfono" required />
+        <input id="phone" name="phone" type="tel" placeholder="Teléfono" required />
 
         <label htmlFor="service">Servicio</label>
-        <select id="service" required>
+        <select id="service" name="service" required>
           <option value="">Selecciona el servicio</option>
           <option value="medicina-interna">Medicina Interna</option>
           <option value="electrocardiograma">Electrocardiograma</option>
@@ -30,10 +57,20 @@ export default function ContactForm() {
         </select>
 
         <label htmlFor="message">Describe tu consulta médica</label>
-        <textarea id="message" placeholder="Describe tu consulta médica" rows="4" required></textarea>
+        <textarea id="message" name="message" placeholder="Describe tu consulta médica" rows="4" required></textarea>
 
         <button type="submit" className={styles.btnPrimary}>Solicitar Cita</button>
       </form>
+      {status === 'success' && (
+        <p role="status" className={styles.successMessage}>
+          Mensaje enviado correctamente. Te contactaremos pronto.
+        </p>
+      )}
+      {status === 'error' && (
+        <p role="alert" className={styles.errorMessage}>
+          Ocurrió un error al enviar tu mensaje. Inténtalo nuevamente.
+        </p>
+      )}
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "^15.4.2",
+        "nodemailer": "^7.0.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0"
@@ -3967,6 +3968,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "^15.4.2",
+    "nodemailer": "^7.0.5",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0"


### PR DESCRIPTION
## Summary
- add API route using Nodemailer to forward contact form submissions to verasaludcali@gmail.com and info@verasalud.com
- submit form data from client and display success or error messages
- document SMTP configuration for sending emails

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689218cebb2c8330aff228e3d2689c65