### PR TITLE
Send contact form submissions via Nodemailer

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,0 +1,2 @@
+SMTP_USER=info@verasalud.com
+SMTP_PASS=your_app_specific_password

--- a/app/Home.module.css
+++ b/app/Home.module.css
@@ -451,6 +451,16 @@
   border-color: var(--primary-cyan);
 }
 
+.successMessage {
+  margin-top: 1rem;
+  color: var(--primary-cyan);
+}
+
+.errorMessage {
+  margin-top: 1rem;
+  color: #dc2626;
+}
+
 /* Footer */
 .footer {
   background-color: var(--primary-blue);

--- a/app/api/contact/route.js
+++ b/app/api/contact/route.js
@@ -1,0 +1,31 @@
+import nodemailer from 'nodemailer'
+
+export async function POST(request) {
+  const { name, email, phone, message } = await request.json()
+
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  })
+
+  try {
+    await transporter.sendMail({
+      from: email,
+      to: 'info@verasalud.com',
+      subject: 'Nuevo mensaje desde VeraSalud.com',
+      text: `\nNombre: ${name}\nEmail: ${email}\nTeléfono: ${phone || 'No ingresado'}\nMensaje: ${message}\n      `
+    })
+
+    return new Response(JSON.stringify({ success: true }), { status: 200 })
+  } catch (error) {
+    console.error(error)
+    return new Response(JSON.stringify({ error: 'Error sending email' }), { status: 500 })
+  }
+}
+
+export async function GET() {
+  return new Response(JSON.stringify({ message: 'Method not allowed' }), { status: 405 })
+}

--- a/app/components/ContactForm.js
+++ b/app/components/ContactForm.js
@@ -1,11 +1,35 @@
 'use client'
 
+import { useState } from 'react'
 import styles from '../Home.module.css'
 
 export default function ContactForm() {
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    alert('Formulario enviado. Nos contactaremos contigo pronto.');
+  const [status, setStatus] = useState(null)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    const formData = new FormData(e.target)
+    const name = formData.get('name')
+    const email = formData.get('email')
+    const phone = formData.get('phone')
+    const message = formData.get('message')
+
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, phone, message })
+      })
+
+      if (res.ok) {
+        setStatus('success')
+        e.target.reset()
+      } else {
+        setStatus('error')
+      }
+    } catch (error) {
+      setStatus('error')
+    }
   }
 
   return (
@@ -13,16 +37,16 @@ export default function ContactForm() {
       <h3>Agenda tu Cita Médica</h3>
       <form onSubmit={handleSubmit}>
         <label htmlFor="name">Nombre completo</label>
-        <input id="name" type="text" placeholder="Nombre completo" required />
+        <input id="name" name="name" type="text" placeholder="Nombre completo" required />
 
         <label htmlFor="email">Email</label>
-        <input id="email" type="email" placeholder="Email" required />
+        <input id="email" name="email" type="email" placeholder="Email" required />
 
         <label htmlFor="phone">Teléfono</label>
-        <input id="phone" type="tel" placeholder="Teléfono" required />
+        <input id="phone" name="phone" type="tel" placeholder="Teléfono" required />
 
         <label htmlFor="service">Servicio</label>
-        <select id="service" required>
+        <select id="service" name="service" required>
           <option value="">Selecciona el servicio</option>
           <option value="medicina-interna">Medicina Interna</option>
           <option value="electrocardiograma">Electrocardiograma</option>
@@ -30,10 +54,20 @@ export default function ContactForm() {
         </select>
 
         <label htmlFor="message">Describe tu consulta médica</label>
-        <textarea id="message" placeholder="Describe tu consulta médica" rows="4" required></textarea>
+        <textarea id="message" name="message" placeholder="Describe tu consulta médica" rows="4" required></textarea>
 
         <button type="submit" className={styles.btnPrimary}>Solicitar Cita</button>
       </form>
+      {status === 'success' && (
+        <p role="status" aria-live="polite" className={styles.successMessage}>
+          Mensaje enviado. Nos contactaremos contigo pronto.
+        </p>
+      )}
+      {status === 'error' && (
+        <p role="status" aria-live="polite" className={styles.errorMessage}>
+          Ocurrió un error. Intenta nuevamente más tarde.
+        </p>
+      )}
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "^15.4.2",
+        "nodemailer": "^6.10.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-icons": "^5.5.0"
@@ -3967,6 +3968,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-assign": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "^15.4.2",
+    "nodemailer": "^6.10.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0"


### PR DESCRIPTION
## Summary
- capture contact form data and submit to `/api/contact` with inline success and error feedback
- add `/api/contact` route that emails submissions to `info@verasalud.com` via Nodemailer
- document SMTP credentials in `.env.local`

## Testing
- `npm run lint`
- `npm run build`
- `node -e "import('./app/api/contact/route.js').then(async m=>{const req=new Request('http://localhost',{method:'POST',body:JSON.stringify({name:'Test',email:'test@example.com',phone:'123',message:'Hola'})}); const res=await m.POST(req); console.log(res.status); console.log(await res.text());}).catch(err=>console.error(err));"` *(fails to connect to Gmail with placeholder credentials)*

------
https://chatgpt.com/codex/tasks/task_e_689236a0dd048330a9532aaf783acae3