### PR TITLE
fix: use optimized webp images for ultrasound pages

### DIFF
--- a/app/servicios/ecografias/abdominal/page.js
+++ b/app/servicios/ecografias/abdominal/page.js
@@ -54,6 +54,7 @@ export default function EcografiaAbdominalPage() {
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía abdominal permite observar hígado, vesícula, páncreas y riñones. Detecta cálculos, masas o inflamación sin usar radiación.
           </p>

--- a/app/servicios/ecografias/doppler/arterial/page.js
+++ b/app/servicios/ecografias/doppler/arterial/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Doppler Arterial en Cali</h1>
           <Image
-            src="/ecografia-doppler-arterial-verasalud.webp"
+            src="/ecografia-doppler-arterial-verasalud-cali.webp"
             alt="Ecografía Doppler arterial en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             El Doppler arterial permite visualizar el flujo sanguíneo en arterias de piernas, brazos o cuello. Útil para detectar obstrucciones o estenosis.
           </p>

--- a/app/servicios/ecografias/doppler/venoso/page.js
+++ b/app/servicios/ecografias/doppler/venoso/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Doppler Venoso en Cali</h1>
           <Image
-            src="/ecografia-doppler-venoso-verasalud.webp"
+            src="/ecografia-doppler-venoso-verasalud-cali.webp"
             alt="Ecografía Doppler venoso en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             El Doppler venoso detecta trombosis, insuficiencia venosa y varices al observar las venas en tiempo real.
           </p>

--- a/app/servicios/ecografias/hepatica/page.js
+++ b/app/servicios/ecografias/hepatica/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía Hepática en Cali</h1>
           <Image
-            src="/ecografia-hepatica-verasalud.webp"
+            src="/ecografia-hepatica-verasalud-cali.webp"
             alt="Ecografía hepática en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía hepática examina el hígado y estructuras vecinas como vesícula y vías biliares. Detecta quistes, masas, grasa hepática y más.
           </p>

--- a/app/servicios/ecografias/mama/page.js
+++ b/app/servicios/ecografias/mama/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía Mamaria en Cali</h1>
           <Image
-            src="/ecografia-mama-verasalud.webp"
-            alt="Ecografía de mama en Cali Verasalud"
+            src="/ecografia-mamaria-verasalud-cali.webp"
+            alt="Ecografía mamaria en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía mamaria permite visualizar tejido mamario en mujeres jóvenes, embarazadas o como complemento de la mamografía.
           </p>

--- a/app/servicios/ecografias/obstetrica/page.js
+++ b/app/servicios/ecografias/obstetrica/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía Obstétrica en Cali</h1>
           <Image
-            src="/ecografia-obstetrica-verasalud.webp"
+            src="/ecografia-obstetrica-tercer-nivel-verasalud-cali.webp"
             alt="Ecografía obstétrica en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía obstétrica evalúa el desarrollo fetal, edad gestacional y bienestar del bebé. Es segura y esencial durante el embarazo.
           </p>

--- a/app/servicios/ecografias/osteomuscular/page.js
+++ b/app/servicios/ecografias/osteomuscular/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía Osteomuscular en Cali</h1>
           <Image
-            src="/ecografia-osteomuscular-verasalud.webp"
+            src="/ecografia-osteomuscular-articular-verasalud-cali.webp"
             alt="Ecografía osteomuscular en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía osteomuscular analiza músculos, tendones y articulaciones. Detecta desgarros, inflamaciones y derrames articulares.
           </p>

--- a/app/servicios/ecografias/pelvica/page.js
+++ b/app/servicios/ecografias/pelvica/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía Pélvica en Cali</h1>
           <Image
-            src="/ecografia-pelvica-verasalud.webp"
+            src="/ecografia-pelvica-ginecologica-verasalud-cali.webp"
             alt="Ecografía pélvica en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía pélvica estudia útero, ovarios y vejiga en mujeres. Detecta miomas, quistes, endometriosis o alteraciones urinarias.
           </p>

--- a/app/servicios/ecografias/prostata/page.js
+++ b/app/servicios/ecografias/prostata/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía de Próstata en Cali</h1>
           <Image
-            src="/ecografia-prostata-verasalud.webp"
-            alt="Ecografía de próstata en Cali Verasalud"
+            src="/ecografia-prostata-verasalud-cali.webp"
+            alt="Ecografía prostática en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía prostática evalúa tamaño y forma de la próstata por vía suprapúbica o transrectal. Útil en síntomas urinarios o chequeo masculino.
           </p>

--- a/app/servicios/ecografias/renal-vias-urinarias/page.js
+++ b/app/servicios/ecografias/renal-vias-urinarias/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía Renal y Vías Urinarias en Cali</h1>
           <Image
-            src="/ecografia-renal-verasalud.webp"
+            src="/ecografia-renal-vias-urinarias-verasalud-cali.webp"
             alt="Ecografía renal y vías urinarias en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía renal examina riñones, uréteres y vejiga. Detecta cálculos, infecciones o alteraciones estructurales.
           </p>

--- a/app/servicios/ecografias/tejidos-blandos/page.js
+++ b/app/servicios/ecografias/tejidos-blandos/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía de Tejidos Blandos en Cali</h1>
           <Image
-            src="/ecografia-tejidos-blandos-verasalud.webp"
+            src="/ecografia-tejidos-blandos-verasalud-cali.webp"
             alt="Ecografía de tejidos blandos en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía de tejidos blandos permite valorar bultos, abscesos, ganglios o lesiones bajo la piel.
           </p>

--- a/app/servicios/ecografias/testicular/page.js
+++ b/app/servicios/ecografias/testicular/page.js
@@ -42,13 +42,14 @@ export default function Page() {
         <div className={styles.heroContent}>
           <h1>Ecografía Testicular en Cali</h1>
           <Image
-            src="/ecografia-testicular-verasalud.webp"
+            src="/ecografia-testicular-verasalud-cali.webp"
             alt="Ecografía testicular en Cali Verasalud"
             width={800}
             height={500}
             style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
             priority
           />
+
           <p>
             La ecografía testicular analiza testículos, epidídimo y vasos. Detecta torsión, quistes, tumores o varicocele.
           </p>

--- a/app/servicios/ecografias/tiroides/page.js
+++ b/app/servicios/ecografias/tiroides/page.js
@@ -45,14 +45,15 @@ export default function EcografiaTiroidesPage() {
       <section className={`${styles.hero} px-4`}>
         <div className={styles.heroContent}>
           <h1>Ecografía de Tiroides en Cali</h1>
-          <Image
-            src="/ecografia-tiroides-verasalud.webp"
-            alt="Ecografía de tiroides en Cali Verasalud"
-            width={800}
-            height={500}
-            style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
-            priority
-          />
+            <Image
+              src="/ecografia-tiroides-verasalud-cali.webp"
+              alt="Ecografía de tiroides en Cali Verasalud"
+              width={800}
+              height={500}
+              style={{ width: '100%', height: 'auto', marginTop: '1rem' }}
+              priority
+            />
+
             <p>
               La ecografía de tiroides observa nódulos, quistes o inflamación en la glándula. No emite radiación y es clave en el seguimiento clínico.
             </p>
@@ -62,8 +63,8 @@ export default function EcografiaTiroidesPage() {
             <p>
               Agenda tu ecografía tiroidea hoy.
             </p>
-        </div>
-      </section>
+          </div>
+        </section>
       <section className={styles.contact}>
         <div className={styles.container}>
           <ContactForm />


### PR DESCRIPTION
## Summary
- replace ultrasound service images with verified `.webp` versions and descriptive alt text

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6892ddbf71b08330b757891f66700304