### PR TITLE
fix: replace hero image on ecografias page

### DIFF
--- a/app/servicios/ecografias/page.js
+++ b/app/servicios/ecografias/page.js
@@ -145,13 +145,14 @@ export default function EcografiasPage() {
       <section className={`${styles.hero} px-4`}>
         <div className={styles.heroContent}>
           <h1>Ecografías en Cali</h1>
-          {/* Fix broken image on ultrasound services page */}
+          {/* Use a real image and make it responsive */}
           <Image
-            src="/ecografia-ultrasonido-general-verasalud-cali.webp"
-            alt="Ecografías en Cali Verasalud"
+            src="/equipo-medico.jpg"
+            alt="Equipo médico de VeraSalud"
             width={1536}
             height={1024}
             priority
+            sizes="(max-width: 768px) 100vw, 50vw"
             className="w-full h-auto mb-4 rounded-md"
           />
           <p>


### PR DESCRIPTION
## Summary
- replace broken hero image with local medical team photo

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68934cb0dd4883308fc7a11db5a322db