### PR TITLE
fix: make ecografias hero image responsive

### DIFF
--- a/app/servicios/ecografias/page.js
+++ b/app/servicios/ecografias/page.js
@@ -145,13 +145,15 @@ export default function EcografiasPage() {
       <section className={`${styles.hero} px-4`}>
         <div className={styles.heroContent}>
         <h1>Ecografías en Cali</h1>
-        <div className="relative w-full h-64 sm:h-80 md:h-[500px] rounded-md overflow-hidden">
+        <div className="w-full">
           <Image
             src="/equipo-medico.jpg"
             alt="Equipo médico de VeraSalud"
-            fill
-            className="object-cover"
+            width={1920}
+            height={1080}
             priority
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 100vw, 100vw"
+            className="w-full h-auto rounded-md"
           />
         </div>
           <p>


### PR DESCRIPTION
## Summary
- replace hero Image component with responsive configuration on ecografias page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68949b86c548833092f2f9b0edbf48f0