### PR TITLE
feat: add permanent redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -93,6 +93,38 @@ const nextConfig = {
         destination: '/servicios/electrocardiograma',
         permanent: true,
       },
+      // Redirección nueva: electrocardiograma singular
+      {
+        source: '/electrocardiograma',
+        destination: '/servicios/electrocardiograma',
+        permanent: true,
+      },
+      // Rutas obsoletas redirigidas a la página de inicio
+      {
+        source: '/assets/:path*',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/liveup/:path*',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/parking.php',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/search/:path*',
+        destination: '/',
+        permanent: true,
+      },
+      {
+        source: '/caf/:path*',
+        destination: '/',
+        permanent: true,
+      },
       // Redirigir index.html a raíz
       {
         source: '/index.html',


### PR DESCRIPTION
## Summary
- redirect singular electrocardiograma to the service page
- route obsolete asset and misc paths to home

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894c97e4fc883308846f4fe77f80900