### PR TITLE
chore: block obsolete directories in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,5 +4,11 @@ User-agent: *
 Allow: /
 
 Disallow: /api/
+# Evitar que Google rastree carpetas obsoletas o spam
+Disallow: /assets/
+Disallow: /liveup/
+Disallow: /parking.php
+Disallow: /search/
+Disallow: /caf/
 
 Sitemap: https://verasalud.com/sitemap.xml


### PR DESCRIPTION
## Summary
- prevent crawling of obsolete or spam directories via robots.txt

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894ca85f00c8330a0b47a4a7038b09c