### PR TITLE
Remove obsolete internal route references

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -99,32 +99,6 @@ const nextConfig = {
         destination: '/servicios/electrocardiograma',
         permanent: true,
       },
-      // Rutas obsoletas redirigidas a la página de inicio
-      {
-        source: '/assets/:path*',
-        destination: '/',
-        permanent: true,
-      },
-      {
-        source: '/liveup/:path*',
-        destination: '/',
-        permanent: true,
-      },
-      {
-        source: '/parking.php',
-        destination: '/',
-        permanent: true,
-      },
-      {
-        source: '/search/:path*',
-        destination: '/',
-        permanent: true,
-      },
-      {
-        source: '/caf/:path*',
-        destination: '/',
-        permanent: true,
-      },
       // Redirigir index.html a raíz
       {
         source: '/index.html',

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,11 +4,5 @@ User-agent: *
 Allow: /
 
 Disallow: /api/
-# Evitar que Google rastree carpetas obsoletas o spam
-Disallow: /assets/
-Disallow: /liveup/
-Disallow: /parking.php
-Disallow: /search/
-Disallow: /caf/
 
 Sitemap: https://verasalud.com/sitemap.xml


### PR DESCRIPTION
## Summary
- drop outdated redirect rules and robots.txt entries for legacy paths
- confirm internal links use updated /servicios routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894cc90d64083309223d68c5ac22816