### PR TITLE
Use WebP for team photos

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -207,9 +207,9 @@ export default function Home() {
           <div className={styles.trustIndicators}>
             <p>✓ Médicos Universidad del Valle  ✓ Sin Demoras  ✓ Alta Tecnología</p>
           </div>
-          {/* TODO: Optimizar esta imagen a formato .webp */}
+          {/* Imagen optimizada en formato .webp */}
           <Image
-            src="/equipo-medico.jpg"
+            src="/equipo-medico.webp"
             alt="Equipo médico de VeraSalud"
             width={1200}
             height={600}

--- a/app/servicios/ecografias/page.js
+++ b/app/servicios/ecografias/page.js
@@ -144,7 +144,7 @@ export default function EcografiasPage() {
       />
       <section className={styles.heroImage}>
         <Image
-          src="/equipo-medico.jpg"
+          src="/equipo-medico.webp"
           alt="Equipo médico de VeraSalud"
           fill
           priority


### PR DESCRIPTION
## Summary
- Serve hero imagery as WebP on homepage and ecografías page for faster load times

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895edaec59c8330a1c9a70f1f1da8a2