### PR TITLE
feat: prioritize hero images for faster load

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -214,6 +214,7 @@ export default function Home() {
             width={1200}
             height={600}
             priority
+            fetchPriority="high"
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
             className={styles.teamPhoto}
           />

--- a/app/servicios/ecografias/page.js
+++ b/app/servicios/ecografias/page.js
@@ -148,6 +148,7 @@ export default function EcografiasPage() {
           alt="Equipo médico de VeraSalud"
           fill
           priority
+          fetchPriority="high"
           sizes="(max-width: 768px) 100vw, 100vw"
           style={{ objectFit: 'cover' }}
         />


### PR DESCRIPTION
## Summary
- improve above-the-fold load times by setting `fetchPriority="high"` on hero images

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689767ce12a483308e7bcaeeb8a1f015