### PR TITLE
feat: update sitemap and robots

### DIFF
--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,6 +1,7 @@
 export async function GET() {
-  const baseUrl = 'https://verasalud.com';
+  const baseUrl = 'https://verasalud.com'
 
+  // Enumera todas las rutas públicas para que Google las descubra
   const staticPaths = [
     '',
     'servicios',
@@ -24,21 +25,22 @@ export async function GET() {
     'videoconsulta',
     'citas',
     'sobre-nosotros',
-    'contacto',
-  ];
+    'contacto'
+  ]
 
   const urls = staticPaths
-    .map((path) =>
-      `<url><loc>${baseUrl}/${path}</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>`
+    .map(
+      (path) =>
+        `<url><loc>${baseUrl}/${path}</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>`
     )
-    .join('');
+    .join('')
 
   const sitemap =
     `<?xml version="1.0" encoding="UTF-8"?>` +
     `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` +
-    `${urls}</urlset>`;
+    `${urls}</urlset>`
 
   return new Response(sitemap, {
-    headers: { 'Content-Type': 'application/xml' },
-  });
+    headers: { 'Content-Type': 'application/xml' }
+  })
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
-# robots.txt de VeraSalud - versión optimizada
+# robots.txt de VeraSalud
 
 User-agent: *
 Allow: /
@@ -6,3 +6,4 @@ Allow: /
 Disallow: /api/
 
 Sitemap: https://verasalud.com/sitemap.xml
+


### PR DESCRIPTION
## Summary
- refactor dynamic sitemap route with consistent style and Spanish comments
- clean up robots.txt and ensure sitemap reference

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68976a89a3f88330832612b581560e84