### PR TITLE
docs: clarify experimental browser settings

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -29,8 +29,11 @@ const nextConfig = {
 
   // Habilita compilación moderna y evita transpilar para navegadores legacy
   swcMinify: true,
+  // Define opciones experimentales para desactivar la compatibilidad con navegadores obsoletos.
   experimental: {
+    // Impide que Next.js incluya polyfills y transformaciones para navegadores antiguos (por ejemplo IE 11)
     legacyBrowsers: false,
+    // Indica a SWC que utilice la configuración de browserslist
     browsersListForSwc: true
   },
 


### PR DESCRIPTION
## Summary
- document experimental options disabling legacy browser support

## Testing
- `npm run lint`
- `npm run build` *(warnings: invalid next.config.js options and unsupported i18n)*

------
https://chatgpt.com/codex/tasks/task_e_6897726a08f883308038ff756fb7b470