### PR TITLE
perf: preconnect analytics domains

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -86,6 +86,10 @@ export default function RootLayout({ children }) {
         <link rel="manifest" href="/site.webmanifest" />
         <meta name="theme-color" content="#21396f" />
 
+        {/* Preconexión con dominios indispensables para evitar cadenas de solicitudes críticas */}
+        <link rel="preconnect" href="https://www.googletagmanager.com" />
+        <link rel="preconnect" href="https://www.google-analytics.com" />
+
         {/* Datos estructurados */}
         <script
           type="application/ld+json"


### PR DESCRIPTION
## Summary
- preconnect to Google Tag Manager and Google Analytics to cut down on request chain

## Testing
- `npm test` (fails: missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68977f0994bc833080694d2165bdd378