### PR TITLE
chore: configure typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,10 @@
       "devDependencies": {
         "@types/node": "24.2.1",
         "@types/react": "19.1.9",
+        "@types/react-dom": "^19.1.7",
         "eslint": "^8.57.1",
-        "eslint-config-next": "15.3.5"
+        "eslint-config-next": "15.3.5",
+        "typescript": "^5.6.3"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -840,6 +842,16 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.7.tgz",
+      "integrity": "sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -5243,7 +5255,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
   "devDependencies": {
     "@types/node": "24.2.1",
     "@types/react": "19.1.9",
+    "@types/react-dom": "^19.1.7",
     "eslint": "^8.57.1",
-    "eslint-config-next": "15.3.5"
+    "eslint-config-next": "15.3.5",
+    "typescript": "^5.6.3"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,39 +1,25 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
     "baseUrl": ".",
     "paths": {
       "@/*": ["./*"]
     },
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "noEmit": true,
     "incremental": true,
-    "module": "esnext",
     "esModuleInterop": true,
-    "moduleResolution": "node",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
+    "forceConsistentCasingInFileNames": true,
+    "plugins": [{ "name": "next" }]
   },
-  "include": [
-    "next-env.d.ts",
-    ".next/types/**/*.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- add TypeScript and @types packages
- configure tsconfig for ES2022, bundler resolution, and path aliases
- commit Next.js `next-env.d.ts` and stop ignoring it

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type error: Cannot find namespace 'JSX')*

------
https://chatgpt.com/codex/tasks/task_e_6898a8fec7308330a1de24a550e5ff93