### PR TITLE
chore: remove React return type

### DIFF
--- a/app/servicios/electrocardiograma/page.tsx
+++ b/app/servicios/electrocardiograma/page.tsx
@@ -63,7 +63,7 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 }
 
-export default function ElectrocardiogramaPage(): JSX.Element {
+export default function ElectrocardiogramaPage() {
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'MedicalTest',


### PR DESCRIPTION
## Summary
- remove explicit React return type from electrocardiograma page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898ab9da3648330b1f9c4730d0f1b86