### PR TITLE
feat: centralize service SEO and metadata

### DIFF
--- a/app/apple-icon.tsx
+++ b/app/apple-icon.tsx
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from 'next'
+import { ImageResponse } from 'next/og'
+
+export function generateImageMetadata(): MetadataRoute.Icon[] {
+  return [
+    { rel: 'apple-touch-icon', url: '/apple-touch-icon.png', sizes: '180x180' },
+  ]
+}
+
+export default function AppleIcon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 64,
+          background: '#21396f',
+          color: 'white',
+        }}
+      >
+        V
+      </div>
+    ),
+    { width: 180, height: 180 }
+  )
+}

--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,0 +1,34 @@
+import type { MetadataRoute } from 'next'
+import { ImageResponse } from 'next/og'
+
+export function generateImageMetadata(): MetadataRoute.Icon[] {
+  return [
+    { rel: 'icon', url: '/favicon-16.png', type: 'image/png', sizes: '16x16' },
+    { rel: 'icon', url: '/favicon-32.png', type: 'image/png', sizes: '32x32' },
+    { rel: 'icon', url: '/favicon-192.png', type: 'image/png', sizes: '192x192' },
+    { rel: 'icon', url: '/favicon-512.png', type: 'image/png', sizes: '512x512' },
+  ]
+}
+
+// Fallback dinámico si faltan los PNG en /public
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontSize: 20,
+          background: '#21396f',
+          color: 'white',
+        }}
+      >
+        VS
+      </div>
+    ),
+    { width: 32, height: 32 }
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,15 @@
 import './globals.css'
 import { Montserrat } from 'next/font/google'
+import type { Metadata, Viewport } from 'next'
 import GA from './components/GA'
 import { Navbar } from '@/components/Navbar'
 import { Footer } from '@/components/Footer'
-import type { Metadata } from 'next'
+import { SITE } from '@/lib/seo'
 
 const montserrat = Montserrat({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://verasalud.com'),
+  metadataBase: new URL(SITE.baseUrl),
   title: {
     default: 'VeraSalud - Medicina Interna y Ecografías en Cali',
     template: '%s | VeraSalud',
@@ -73,6 +74,16 @@ export const metadata: Metadata = {
   // verification: {
   //   google: 'tu-codigo-de-verificacion', // Agregar cuando tengas Google Search Console
   // },
+}
+
+// Viewport dinámico (puede extenderse según preferencias)
+export function generateViewport(): Viewport {
+  return {
+    width: 'device-width',
+    initialScale: 1,
+    themeColor: '#21396f',
+    colorScheme: 'light',
+  }
 }
 
 export default function RootLayout({

--- a/app/servicios/consulta-medica/page.tsx
+++ b/app/servicios/consulta-medica/page.tsx
@@ -1,15 +1,33 @@
-import { Metadata } from 'next';
-import Image from 'next/image';
-import ContactForm from '@/components/ContactForm';
-import styles from '@/styles/Home.module.css';
-import Link from 'next/link';
+import { Metadata } from 'next'
+import Image from 'next/image'
+import ContactForm from '@/components/ContactForm'
+import styles from '@/styles/Home.module.css'
+import Link from 'next/link'
+import { buildMetadata, getServiceSEO, buildBreadcrumbJSONLD, SITE } from '@/lib/seo'
 
 export async function generateMetadata(): Promise<Metadata> {
+  const s = await getServiceSEO('consulta-medica')
+  if (s) return buildMetadata(s)
+  return {
+    title: 'Consulta de Medicina Interna | VeraSalud',
+    description:
+      'Consulta de medicina interna con especialistas. Diagnóstico integral y manejo de enfermedades crónicas en Cali.',
+    alternates: { canonical: `${SITE.baseUrl}/servicios/consulta-medica` },
+  }
+}
+
+export default function ConsultaMedicaPage() {
+  const breadcrumb = buildBreadcrumbJSONLD([
+    { name: 'Inicio', item: SITE.baseUrl },
+    { name: 'Servicios', item: `${SITE.baseUrl}/servicios` },
+    { name: 'Consulta de Medicina Interna' },
+  ])
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'MedicalProcedure',
     name: 'Consulta de Medicina Interna',
-    description: 'Consulta médica especializada para diagnóstico integral y control de enfermedades crónicas en adultos.',
+    description:
+      'Consulta médica especializada para diagnóstico integral y control de enfermedades crónicas en adultos.',
     url: 'https://verasalud.com/servicios/consulta-medica',
     provider: {
       '@type': 'MedicalOrganization',
@@ -19,85 +37,27 @@ export async function generateMetadata(): Promise<Metadata> {
         '@type': 'PostalAddress',
         addressLocality: 'Cali',
         addressRegion: 'Valle del Cauca',
-        addressCountry: 'CO'
-      }
+        addressCountry: 'CO',
+      },
     },
     availableService: [
-      {
-        '@type': 'MedicalTherapy',
-        name: 'Diagnóstico de Diabetes'
-      },
-      {
-        '@type': 'MedicalTherapy', 
-        name: 'Control de Hipertensión'
-      },
-      {
-        '@type': 'MedicalTherapy',
-        name: 'Manejo de Dislipidemia'
-      },
-      {
-        '@type': 'MedicalTherapy',
-        name: 'Tratamiento de Enfermedades de Tiroides'
-      }
-    ]
-  };
-
-  return {
-    title: 'Consulta de Medicina Interna en Cali – Especialistas VeraSalud',
-    description: 'Consulta de medicina interna con especialistas de la Universidad del Valle en VeraSalud. Diagnóstico integral y manejo de enfermedades crónicas sin filas ni demoras en Cali.',
-    keywords: [
-      'medicina interna Cali',
-      'internista Cali',
-      'consulta médica especializada',
-      'diabetes hipertensión',
-      'enfermedades crónicas',
-      'médicos Universidad del Valle',
-      'consulta sin demoras Cali'
+      { '@type': 'MedicalTherapy', name: 'Diagnóstico de Diabetes' },
+      { '@type': 'MedicalTherapy', name: 'Control de Hipertensión' },
+      { '@type': 'MedicalTherapy', name: 'Manejo de Dislipidemia' },
+      { '@type': 'MedicalTherapy', name: 'Tratamiento de Enfermedades de Tiroides' },
     ],
-    openGraph: {
-      title: 'Consulta de Medicina Interna en Cali – VeraSalud',
-      description: 'Consulta médica especializada con internistas de VeraSalud en Cali.',
-      url: 'https://verasalud.com/servicios/consulta-medica',
-      images: [
-        { 
-          url: 'https://verasalud.com/equipo-medico.webp', 
-          width: 1200, 
-          height: 800, 
-          alt: 'Médicos internistas de VeraSalud en Cali' 
-        }
-      ],
-      locale: 'es_CO',
-      type: 'article'
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title: 'Consulta de Medicina Interna en Cali – VeraSalud',
-      description: 'Agenda tu consulta con internistas de la Universidad del Valle en Cali.',
-      images: ['https://verasalud.com/equipo-medico.webp']
-    },
-    alternates: {
-      canonical: 'https://verasalud.com/servicios/consulta-medica'
-    },
-    robots: {
-      index: true,
-      follow: true,
-      googleBot: {
-        index: true,
-        follow: true,
-        'max-video-preview': -1,
-        'max-image-preview': 'large',
-        'max-snippet': -1,
-      },
-    },
-    other: {
-      'application/ld+json': JSON.stringify(jsonLd)
-    }
-  };
-}
+  }
 
-export default function ConsultaMedicaPage() {
   return (
-    <main className="container dark-fix">
+    <main className={`${styles.container} dark-fix`}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <section className="hero">
         <div className="heroContent">
           <h1>Consulta de Medicina Interna en Cali</h1>
@@ -105,7 +65,7 @@ export default function ConsultaMedicaPage() {
             Valoración integral de tu salud por internistas especializados en enfermedades crónicas,
             diagnóstico temprano y tratamiento personalizado.
           </p>
-          
+
           <figure style={{ marginTop: '2rem', marginBottom: '2rem' }}>
             <Image
               src="/equipo-medico.webp"
@@ -116,16 +76,18 @@ export default function ConsultaMedicaPage() {
               priority
               style={{ width: '100%', height: 'auto', borderRadius: '8px' }}
             />
-            <figcaption style={{ 
-              textAlign: 'center', 
-              fontSize: '0.9rem', 
-              color: '#555', 
-              marginTop: '0.5rem' 
-            }}>
+            <figcaption
+              style={{
+                textAlign: 'center',
+                fontSize: '0.9rem',
+                color: '#555',
+                marginTop: '0.5rem',
+              }}
+            >
               Consulta de Medicina Interna con especialistas en VeraSalud – Cali
             </figcaption>
           </figure>
-          
+
           <h2>Atención especializada sin demoras</h2>
           <p>
             En VeraSalud ofrecemos diagnóstico y control de diabetes, hipertensión, dislipidemia,
@@ -136,7 +98,7 @@ export default function ConsultaMedicaPage() {
           </p>
         </div>
       </section>
-      
+
       <section className="contact">
         <div className="container">
           <ContactForm />
@@ -146,6 +108,6 @@ export default function ConsultaMedicaPage() {
         </div>
       </section>
     </main>
-  );
+  )
 }
 

--- a/app/servicios/ecografias/abdominal/page.js
+++ b/app/servicios/ecografias/abdominal/page.js
@@ -3,30 +3,22 @@ import ContactForm from '../../../components/ContactForm'
 import styles from '../../../Home.module.css'
 import Link from 'next/link'
 
-export const metadata = {
-  title: 'Ecografía Abdominal en Cali | VeraSalud',
-  description: 'Ultrasonido abdominal para evaluar órganos internos y detectar patologías en VeraSalud.',
-  keywords: ['ecografia abdominal cali', 'ultrasonido de abdomen', 'imagen diagnostica cali'],
-  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/abdominal' },
-  openGraph: {
+export async function generateMetadata() {
+  return {
     title: 'Ecografía Abdominal en Cali | VeraSalud',
-    description: 'Estudio ecográfico de abdomen con tecnología de alta resolución en Cali.',
-    url: 'https://verasalud.com/servicios/ecografias/abdominal',
-    images: [
-      {
-        url: '/ecografia-abdominal-verasalud-cali.webp',
-        width: 1200,
-        height: 630,
-        alt: 'Equipo realizando ecografía abdominal en Cali'
-      }
-    ],
-    locale: 'es_CO',
-    type: 'article'
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Ecografía Abdominal en VeraSalud',
-    description: 'Diagnóstico preciso de hígado, riñones y vesícula con ecografía abdominal.'
+    description:
+      'Ecografía abdominal para evaluación de hígado, vesícula y riñones con equipos de alta resolución. VeraSalud Cali.',
+    openGraph: {
+      title: 'Ecografía Abdominal en Cali | VeraSalud',
+      description:
+        'Ecografía abdominal de alta calidad con resultados confiables en VeraSalud Cali.',
+      url: '/servicios/ecografias/abdominal',
+      images: [
+        { url: '/ecografia-abdominal-verasalud-cali.webp', width: 1200, height: 630 },
+      ],
+    },
+    alternates: { canonical: '/servicios/ecografias/abdominal' },
+    keywords: ['ecografía abdominal Cali', 'ultrasonido abdomen', 'ecografías Cali'],
   }
 }
 

--- a/app/servicios/ecografias/doppler/page.js
+++ b/app/servicios/ecografias/doppler/page.js
@@ -3,25 +3,22 @@ import ContactForm from '../../../components/ContactForm'
 import styles from '../../../Home.module.css'
 import Link from 'next/link'
 
-export const metadata = {
-  title: 'Ecografía Doppler en Cali | VeraSalud',
-  description: 'Estudio Doppler para evaluar el flujo sanguíneo en arterias y venas, detectando obstrucciones y trombosis.',
-  keywords: ['ecografia doppler cali', 'ultrasonido vascular', 'doppler venoso arterial'],
-  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/doppler' },
-  openGraph: {
+export async function generateMetadata() {
+  return {
     title: 'Ecografía Doppler en Cali | VeraSalud',
-    description: 'Estudio Doppler para evaluar el flujo sanguíneo en arterias y venas, detectando obstrucciones y trombosis.',
-    url: 'https://verasalud.com/servicios/ecografias/doppler',
-    images: [
-      { url: '/ecografia-doppler-arterial-verasalud-cali.webp', width: 1200, height: 630, alt: 'Ecografía Doppler de miembros en VeraSalud' }
-    ],
-    locale: 'es_CO',
-    type: 'article'
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Ecografía Doppler en Cali | VeraSalud',
-    description: 'Estudio Doppler para evaluar el flujo sanguíneo en arterias y venas, detectando obstrucciones y trombosis.'
+    description:
+      'Ecografía Doppler arterial y venosa para evaluación vascular. Atención oportuna en VeraSalud Cali.',
+    openGraph: {
+      title: 'Ecografía Doppler en Cali | VeraSalud',
+      description:
+        'Ecografía Doppler con equipos de alta resolución en VeraSalud Cali.',
+      url: '/servicios/ecografias/doppler',
+      images: [
+        { url: '/ecografia-doppler-arterial-verasalud-cali.webp', width: 1200, height: 630 },
+      ],
+    },
+    alternates: { canonical: '/servicios/ecografias/doppler' },
+    keywords: ['ecografía doppler Cali', 'ultrasonido vascular', 'doppler venoso arterial'],
   }
 }
 

--- a/app/servicios/ecografias/hepatica/page.js
+++ b/app/servicios/ecografias/hepatica/page.js
@@ -3,25 +3,22 @@ import ContactForm from '../../../components/ContactForm'
 import styles from '../../../Home.module.css'
 import Link from 'next/link'
 
-export const metadata = {
-  title: 'Ecografía Hepática en Cali | VeraSalud',
-  description: 'Diagnóstico preciso del hígado y vías biliares con ecografía hepática especializada en Cali.',
-  keywords: ['ecografia hepatica cali', 'ultrasonido de higado', 'diagnostico higado cali'],
-  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/hepatica' },
-  openGraph: {
+export async function generateMetadata() {
+  return {
     title: 'Ecografía Hepática en Cali | VeraSalud',
-    description: 'Diagnóstico preciso del hígado y vías biliares con ecografía hepática especializada en Cali.',
-    url: 'https://verasalud.com/servicios/ecografias/hepatica',
-    images: [
-      { url: '/ecografia-hepatica-verasalud-cali.webp', width: 1200, height: 630, alt: 'Equipo realizando ecografía hepática en VeraSalud' }
-    ],
-    locale: 'es_CO',
-    type: 'article'
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Ecografía Hepática en Cali | VeraSalud',
-    description: 'Diagnóstico preciso del hígado y vías biliares con ecografía hepática especializada en Cali.'
+    description:
+      'Ecografía hepática para evaluación de hígado y vías biliares con alta resolución. VeraSalud Cali.',
+    openGraph: {
+      title: 'Ecografía Hepática en Cali | VeraSalud',
+      description:
+        'Ecografía hepática con resultados confiables en VeraSalud Cali.',
+      url: '/servicios/ecografias/hepatica',
+      images: [
+        { url: '/ecografia-hepatica-verasalud-cali.webp', width: 1200, height: 630 },
+      ],
+    },
+    alternates: { canonical: '/servicios/ecografias/hepatica' },
+    keywords: ['ecografía hepática Cali', 'hígado ecografía', 'vías biliares'],
   }
 }
 

--- a/app/servicios/ecografias/mama/page.js
+++ b/app/servicios/ecografias/mama/page.js
@@ -3,25 +3,22 @@ import ContactForm from '../../../components/ContactForm'
 import styles from '../../../Home.module.css'
 import Link from 'next/link'
 
-export const metadata = {
-  title: 'Ecografía Mamaria en Cali | VeraSalud',
-  description: 'Diagnóstico por ultrasonido de la mama para distinguir entre quistes y tumores y complementar la mamografía.',
-  keywords: ['ecografia mamaria cali', 'ultrasonido mama', 'ecografia de seno cali'],
-  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/mama' },
-  openGraph: {
+export async function generateMetadata() {
+  return {
     title: 'Ecografía Mamaria en Cali | VeraSalud',
-    description: 'Diagnóstico por ultrasonido de la mama para distinguir entre quistes y tumores y complementar la mamografía.',
-    url: 'https://verasalud.com/servicios/ecografias/mama',
-    images: [
-      { url: '/ecografia-mamaria-verasalud-cali.webp', width: 1200, height: 630, alt: 'Realizando ecografía mamaria en VeraSalud' }
-    ],
-    locale: 'es_CO',
-    type: 'article'
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Ecografía Mamaria en Cali | VeraSalud',
-    description: 'Diagnóstico por ultrasonido de la mama para distinguir entre quistes y tumores y complementar la mamografía.'
+    description:
+      'Ecografía de mama de alta resolución para evaluación y control en VeraSalud Cali.',
+    openGraph: {
+      title: 'Ecografía Mamaria en Cali | VeraSalud',
+      description:
+        'Ecografía mamaria con equipos de alta resolución en VeraSalud Cali.',
+      url: '/servicios/ecografias/mama',
+      images: [
+        { url: '/ecografia-mamaria-verasalud-cali.webp', width: 1200, height: 630 },
+      ],
+    },
+    alternates: { canonical: '/servicios/ecografias/mama' },
+    keywords: ['ecografía mamaria Cali', 'ultrasonido de mama', 'control de mama'],
   }
 }
 

--- a/app/servicios/ecografias/obstetrica/page.js
+++ b/app/servicios/ecografias/obstetrica/page.js
@@ -3,25 +3,22 @@ import ContactForm from '../../../components/ContactForm'
 import styles from '../../../Home.module.css'
 import Link from 'next/link'
 
-export const metadata = {
-  title: 'Ecografía Obstétrica en Cali | VeraSalud',
-  description: 'Monitorización del embarazo y desarrollo fetal mediante ultrasonido seguro y confiable.',
-  keywords: ['ecografia obstetrica cali', 'ultrasonido embarazo', 'ecografia prenatal cali'],
-  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/obstetrica' },
-  openGraph: {
+export async function generateMetadata() {
+  return {
     title: 'Ecografía Obstétrica en Cali | VeraSalud',
-    description: 'Monitorización del embarazo y desarrollo fetal mediante ultrasonido seguro y confiable.',
-    url: 'https://verasalud.com/servicios/ecografias/obstetrica',
-    images: [
-      { url: '/ecografia-obstetrica-tercer-nivel-verasalud-cali.webp', width: 1200, height: 630, alt: 'Ecografía obstétrica en VeraSalud' }
-    ],
-    locale: 'es_CO',
-    type: 'article'
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Ecografía Obstétrica en Cali | VeraSalud',
-    description: 'Monitorización del embarazo y desarrollo fetal mediante ultrasonido seguro y confiable.'
+    description:
+      'Ecografía obstétrica para control prenatal con alta resolución. VeraSalud Cali.',
+    openGraph: {
+      title: 'Ecografía Obstétrica en Cali | VeraSalud',
+      description:
+        'Ecografía obstétrica con resultados confiables en VeraSalud Cali.',
+      url: '/servicios/ecografias/obstetrica',
+      images: [
+        { url: '/ecografia-obstetrica-tercer-nivel-verasalud-cali.webp', width: 1200, height: 630 },
+      ],
+    },
+    alternates: { canonical: '/servicios/ecografias/obstetrica' },
+    keywords: ['ecografía obstétrica Cali', 'control prenatal', 'ultrasonido embarazo'],
   }
 }
 

--- a/app/servicios/ecografias/osteomuscular/page.js
+++ b/app/servicios/ecografias/osteomuscular/page.js
@@ -3,25 +3,22 @@ import ContactForm from '../../../components/ContactForm'
 import styles from '../../../Home.module.css'
 import Link from 'next/link'
 
-export const metadata = {
-  title: 'Ecografía Osteomuscular en Cali | VeraSalud',
-  description: 'Evaluación de músculos, tendones y articulaciones mediante ultrasonido dinámico.',
-  keywords: ['ecografia osteomuscular cali', 'ultrasonido musculos', 'ecografia articular cali'],
-  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/osteomuscular' },
-  openGraph: {
+export async function generateMetadata() {
+  return {
     title: 'Ecografía Osteomuscular en Cali | VeraSalud',
-    description: 'Evaluación de músculos, tendones y articulaciones mediante ultrasonido dinámico.',
-    url: 'https://verasalud.com/servicios/ecografias/osteomuscular',
-    images: [
-      { url: '/ecografia-osteomuscular-articular-verasalud-cali.webp', width: 1200, height: 630, alt: 'Ecografía osteomuscular en VeraSalud' }
-    ],
-    locale: 'es_CO',
-    type: 'article'
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Ecografía Osteomuscular en Cali | VeraSalud',
-    description: 'Evaluación de músculos, tendones y articulaciones mediante ultrasonido dinámico.'
+    description:
+      'Ecografía osteomuscular para evaluación de tendones, ligamentos y articulaciones. VeraSalud Cali.',
+    openGraph: {
+      title: 'Ecografía Osteomuscular en Cali | VeraSalud',
+      description:
+        'Ecografía osteomuscular con equipos de alta resolución en VeraSalud Cali.',
+      url: '/servicios/ecografias/osteomuscular',
+      images: [
+        { url: '/ecografia-osteomuscular-articular-verasalud-cali.webp', width: 1200, height: 630 },
+      ],
+    },
+    alternates: { canonical: '/servicios/ecografias/osteomuscular' },
+    keywords: ['ecografía osteomuscular Cali', 'tendones', 'ligamentos', 'articulaciones'],
   }
 }
 

--- a/app/servicios/ecografias/page.js
+++ b/app/servicios/ecografias/page.js
@@ -3,26 +3,19 @@ import ContactForm from '../../components/ContactForm'
 import styles from '../../Home.module.css'
 import Link from 'next/link'
 
-export const metadata = {
-  title: 'Ecografías en Cali | Ultrasonido y Doppler | VeraSalud',
-  description:
-    'Ecografías de alta resolución en Cali con radiólogos expertos. Sin filas, resultados precisos y atención profesional. Agenda tu estudio.',
-  keywords: ['ecografias cali', 'ecografia doppler', 'ecografia abdominal', 'ultrasonido en cali'],
-  alternates: { canonical: 'https://verasalud.com/servicios/ecografias' },
-  openGraph: {
-    title: 'Ecografías en Cali | VeraSalud',
-    description: 'Ultrasonido convencional y Doppler en Cali para diagnósticos precisos.',
-    url: 'https://verasalud.com/servicios/ecografias',
-    images: [
-      { url: '/og-image.jpg', width: 1200, height: 630, alt: 'Ecografías en VeraSalud Cali' }
-    ],
-    locale: 'es_CO',
-    type: 'website'
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Ecografías de Alta Resolución en Cali',
-    description: 'Solicita tu ecografía con especialistas en VeraSalud.'
+export async function generateMetadata() {
+  return {
+    title: 'Ecografías de Alta Resolución en Cali | VeraSalud',
+    description:
+      'Ecografías convencionales y Doppler con tecnología avanzada y radiólogos expertos en VeraSalud Cali.',
+    keywords: ['ecografías Cali', 'ecografía doppler', 'ultrasonido Cali'],
+    openGraph: {
+      title: 'Ecografías en Cali | VeraSalud',
+      description:
+        'Ecografías de alta resolución realizadas por profesionales con experiencia clínica.',
+      url: '/servicios/ecografias',
+    },
+    alternates: { canonical: '/servicios/ecografias' },
   }
 }
 

--- a/app/servicios/ecografias/pelvica/page.js
+++ b/app/servicios/ecografias/pelvica/page.js
@@ -3,25 +3,22 @@ import ContactForm from '../../../components/ContactForm'
 import styles from '../../../Home.module.css'
 import Link from 'next/link'
 
-export const metadata = {
-  title: 'Ecografía Pélvica en Cali | VeraSalud',
-  description: 'Evaluación ecográfica del útero, ovarios y vejiga para diagnosticar afecciones ginecológicas y urológicas.',
-  keywords: ['ecografia pelvica cali', 'ultrasonido ginecologico', 'ecografia transvaginal cali'],
-  alternates: { canonical: 'https://verasalud.com/servicios/ecografias/pelvica' },
-  openGraph: {
+export async function generateMetadata() {
+  return {
     title: 'Ecografía Pélvica en Cali | VeraSalud',
-    description: 'Evaluación ecográfica del útero, ovarios y vejiga para diagnosticar afecciones ginecológicas y urológicas.',
-    url: 'https://verasalud.com/servicios/ecografias/pelvica',
-    images: [
-      { url: '/ecografia-pelvica-ginecologica-verasalud-cali.webp', width: 1200, height: 630, alt: 'Ecografía pélvica ginecológica en VeraSalud' }
-    ],
-    locale: 'es_CO',
-    type: 'article'
-  },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'Ecografía Pélvica en Cali | VeraSalud',
-    description: 'Evaluación ecográfica del útero, ovarios y vejiga para diagnosticar afecciones ginecológicas y urológicas.'
+    description:
+      'Ecografía pélvica femenina con alta calidad de imagen. Resultados confiables en VeraSalud Cali.',
+    openGraph: {
+      title: 'Ecografía Pélvica en Cali | VeraSalud',
+      description:
+        'Ecografía pélvica con equipos de alta resolución en VeraSalud Cali.',
+      url: '/servicios/ecografias/pelvica',
+      images: [
+        { url: '/ecografia-pelvica-ginecologica-verasalud-cali.webp', width: 1200, height: 630 },
+      ],
+    },
+    alternates: { canonical: '/servicios/ecografias/pelvica' },
+    keywords: ['ecografía pélvica Cali', 'ultrasonido pélvico', 'ginecológica'],
   }
 }
 

--- a/app/servicios/electrocardiograma/page.tsx
+++ b/app/servicios/electrocardiograma/page.tsx
@@ -1,69 +1,27 @@
 import Image from 'next/image'
-import ContactForm from '../../components/ContactForm'
-import styles from '../../Home.module.css'
+import ContactForm from '@/components/ContactForm'
+import styles from '@/styles/Home.module.css'
 import Link from 'next/link'
 import type { Metadata } from 'next'
+import { buildMetadata, getServiceSEO, buildBreadcrumbJSONLD, SITE } from '@/lib/seo'
 
 export async function generateMetadata(): Promise<Metadata> {
-  const title = 'Electrocardiograma en Cali | Rápido y Confiable | VeraSalud'
-  const description =
-    'Realiza tu electrocardiograma en VeraSalud Cali. Detección de arritmias y riesgos cardíacos sin filas, con equipos digitales y lectura por especialistas. Agenda tu cita.'
-  const pageUrl = '/servicios/electrocardiograma'
-  const baseUrl = 'https://verasalud.com'
-  const imageUrl = `${baseUrl}/electrocardiograma-verasalud-cali.webp`
-
+  const s = await getServiceSEO('electrocardiograma')
+  if (s) return buildMetadata(s)
   return {
-    title,
-    description,
-    alternates: { canonical: pageUrl },
-    openGraph: {
-      title,
-      description:
-        'En VeraSalud realizamos tu electrocardiograma con atención sin demoras, equipos digitales y lectura inmediata por especialistas.',
-      url: pageUrl,
-      images: [
-        {
-          url: imageUrl,
-          width: 1200,
-          height: 800,
-          alt: 'Paciente realizándose un electrocardiograma en VeraSalud Cali.',
-        },
-      ],
-      locale: 'es_CO',
-      type: 'website',
-      siteName: 'VeraSalud',
-    },
-    twitter: {
-      card: 'summary_large_image',
-      title,
-      description,
-      images: [imageUrl],
-    },
-    robots: {
-      index: true,
-      follow: true,
-      googleBot: {
-        index: true,
-        follow: true,
-        'max-video-preview': -1,
-        'max-image-preview': 'large',
-        'max-snippet': -1,
-      },
-    },
-    keywords: [
-      'electrocardiograma Cali',
-      'ECG Cali',
-      'arritmias',
-      'bloqueos de rama',
-      'chequeo cardiaco',
-      'resultados inmediatos',
-      'verasalud',
-    ],
-    authors: [{ name: 'VeraSalud' }],
+    title: 'Electrocardiograma en Cali | VeraSalud',
+    description:
+      'Electrocardiograma digital con lectura por especialistas. Atención sin demoras en VeraSalud Cali.',
+    alternates: { canonical: `${SITE.baseUrl}/servicios/electrocardiograma` },
   }
 }
 
 export default function ElectrocardiogramaPage() {
+  const breadcrumb = buildBreadcrumbJSONLD([
+    { name: 'Inicio', item: SITE.baseUrl },
+    { name: 'Servicios', item: `${SITE.baseUrl}/servicios` },
+    { name: 'Electrocardiograma' },
+  ])
   const jsonLd = {
     '@context': 'https://schema.org',
     '@type': 'MedicalTest',
@@ -94,6 +52,10 @@ export default function ElectrocardiogramaPage() {
 
   return (
     <main className={`${styles.container} dark-fix`}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumb) }}
+      />
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,192 @@
+import { cache } from 'react'
+import type { Metadata } from 'next'
+
+export const SITE = {
+  name: 'VeraSalud',
+  baseUrl: 'https://verasalud.com',
+  locale: 'es_CO',
+  twitter: '@verasalud'
+}
+
+type ServiceSEO = {
+  slug: string
+  title: string
+  description: string
+  path: string
+  image: string
+  ogAlt?: string
+  type?: 'website' | 'article'
+  keywords?: string[]
+}
+
+// Fuente central de verdad para metadatos por servicio
+const SERVICES: Record<string, ServiceSEO> = {
+  'consulta-medica': {
+    slug: 'consulta-medica',
+    title: 'Consulta de Medicina Interna en Cali – Especialistas VeraSalud',
+    description:
+      'Consulta de medicina interna con especialistas de la Universidad del Valle. Diagnóstico integral y manejo de enfermedades crónicas sin filas ni demoras en Cali.',
+    path: '/servicios/consulta-medica',
+    image: '/equipo-medico.webp',
+    ogAlt: 'Médicos internistas de VeraSalud en Cali',
+    type: 'article',
+    keywords: [
+      'medicina interna Cali',
+      'internista Cali',
+      'consulta médica especializada',
+      'diabetes',
+      'hipertensión',
+      'enfermedades crónicas'
+    ]
+  },
+  electrocardiograma: {
+    slug: 'electrocardiograma',
+    title: 'Electrocardiograma en Cali | Rápido y Confiable | VeraSalud',
+    description:
+      'Electrocardiograma digital para detección de arritmias y riesgos cardíacos. Atención sin demoras con lectura por especialistas en VeraSalud Cali.',
+    path: '/servicios/electrocardiograma',
+    image: '/electrocardiograma-verasalud-cali.webp',
+    ogAlt: 'Paciente realizándose un electrocardiograma en VeraSalud Cali',
+    type: 'website',
+    keywords: [
+      'electrocardiograma Cali',
+      'ECG Cali',
+      'arritmias',
+      'bloqueos de rama',
+      'chequeo cardiaco',
+      'resultados inmediatos'
+    ]
+  },
+  // Ecografías (añade/ajusta según tus páginas disponibles)
+  'ecografias/abdominal': {
+    slug: 'ecografias/abdominal',
+    title: 'Ecografía Abdominal en Cali | VeraSalud',
+    description:
+      'Ecografía abdominal de alta resolución para evaluación de hígado, vesícula y riñones. Resultados confiables en VeraSalud Cali.',
+    path: '/servicios/ecografias/abdominal',
+    image: '/ecografia-abdominal-verasalud-cali.webp',
+    ogAlt: 'Ecografía abdominal en VeraSalud Cali',
+    type: 'article',
+    keywords: ['ecografía abdominal Cali', 'ultrasonido abdomen', 'ecografías Cali']
+  },
+  'ecografias/doppler': {
+    slug: 'ecografias/doppler',
+    title: 'Ecografía Doppler en Cali | VeraSalud',
+    description:
+      'Ecografía Doppler arterial y venosa para evaluación vascular. Equipos de alta resolución en VeraSalud Cali.',
+    path: '/servicios/ecografias/doppler',
+    image: '/ecografia-doppler-verasalud-cali.webp',
+    ogAlt: 'Ecografía Doppler en VeraSalud Cali',
+    type: 'article',
+    keywords: ['ecografía doppler Cali', 'doppler venoso', 'doppler arterial']
+  },
+  'ecografias/hepatica': {
+    slug: 'ecografias/hepatica',
+    title: 'Ecografía Hepática en Cali | VeraSalud',
+    description:
+      'Ecografía hepática para evaluación de hígado y vías biliares. Atención oportuna en VeraSalud Cali.',
+    path: '/servicios/ecografias/hepatica',
+    image: '/ecografia-hepatica-verasalud-cali.webp',
+    ogAlt: 'Ecografía hepática en VeraSalud Cali',
+    type: 'article',
+    keywords: ['ecografía hepática Cali', 'hígado ecografía', 'vías biliares']
+  },
+  'ecografias/mama': {
+    slug: 'ecografias/mama',
+    title: 'Ecografía Mamaria en Cali | VeraSalud',
+    description:
+      'Ecografía de mama de alta resolución para evaluación y control. VeraSalud Cali.',
+    path: '/servicios/ecografias/mama',
+    image: '/ecografia-mamaria-verasalud-cali.webp',
+    ogAlt: 'Ecografía mamaria en VeraSalud Cali',
+    type: 'article',
+    keywords: ['ecografía mamaria Cali', 'ultrasonido de mama', 'control de mama']
+  },
+  'ecografias/osteomuscular': {
+    slug: 'ecografias/osteomuscular',
+    title: 'Ecografía Osteomuscular en Cali | VeraSalud',
+    description:
+      'Ecografía osteomuscular para tendones, ligamentos y articulaciones. VeraSalud Cali.',
+    path: '/servicios/ecografias/osteomuscular',
+    image: '/ecografia-osteomuscular-verasalud-cali.webp',
+    ogAlt: 'Ecografía osteomuscular en VeraSalud Cali',
+    type: 'article',
+    keywords: ['ecografía osteomuscular Cali', 'tendones ligamentos ecografía']
+  },
+  'ecografias/pelvica': {
+    slug: 'ecografias/pelvica',
+    title: 'Ecografía Pélvica en Cali | VeraSalud',
+    description:
+      'Ecografía pélvica femenina con alta calidad de imagen. Resultados confiables en VeraSalud Cali.',
+    path: '/servicios/ecografias/pelvica',
+    image: '/ecografia-pelvica-verasalud-cali.webp',
+    ogAlt: 'Ecografía pélvica en VeraSalud Cali',
+    type: 'article',
+    keywords: ['ecografía pélvica Cali', 'ultrasonido pélvico', 'ginecológica']
+  },
+  'ecografias/obstetrica': {
+    slug: 'ecografias/obstetrica',
+    title: 'Ecografía Obstétrica en Cali | VeraSalud',
+    description:
+      'Ecografía obstétrica para control prenatal con equipos de alta resolución. VeraSalud Cali.',
+    path: '/servicios/ecografias/obstetrica',
+    image: '/ecografia-obstetrica-verasalud-cali.webp',
+    ogAlt: 'Ecografía obstétrica en VeraSalud Cali',
+    type: 'article',
+    keywords: ['ecografía obstétrica Cali', 'control prenatal', 'ultrasonido embarazo']
+  }
+}
+
+export const getServiceSEO = cache(async (slug: string): Promise<ServiceSEO | null> => {
+  return SERVICES[slug] ?? null
+})
+
+export function buildMetadata(s: ServiceSEO): Metadata {
+  const url = new URL(s.path, SITE.baseUrl).toString()
+  const ogImage = new URL(s.image, SITE.baseUrl).toString()
+  return {
+    title: s.title,
+    description: s.description,
+    keywords: s.keywords,
+    alternates: { canonical: url },
+    openGraph: {
+      title: s.title,
+      description: s.description,
+      url,
+      siteName: SITE.name,
+      images: [{ url: ogImage, width: 1200, height: 630, alt: s.ogAlt || s.title }],
+      locale: SITE.locale,
+      type: s.type || 'article'
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: s.title,
+      description: s.description,
+      images: [ogImage]
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-video-preview': -1,
+        'max-image-preview': 'large',
+        'max-snippet': -1
+      }
+    }
+  }
+}
+
+export function buildBreadcrumbJSONLD(crumbs: Array<{ name: string; item?: string }>) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: crumbs.map((c, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: c.name,
+      ...(c.item ? { item: c.item } : {})
+    }))
+  }
+}


### PR DESCRIPTION
## Summary
- centralize service SEO metadata and breadcrumbs
- expose site config in layout with dynamic viewport
- add typed icon routes for favicon and apple-touch icons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898ca4ebd808330ae4213ff2cad30ef