### PR TITLE
feat: add SVG-based app icon

### DIFF
--- a/app/icon.tsx
+++ b/app/icon.tsx
@@ -1,34 +1,16 @@
-import type { MetadataRoute } from 'next'
 import { ImageResponse } from 'next/og'
 
-export function generateImageMetadata(): MetadataRoute.Icon[] {
-  return [
-    { rel: 'icon', url: '/favicon-16.png', type: 'image/png', sizes: '16x16' },
-    { rel: 'icon', url: '/favicon-32.png', type: 'image/png', sizes: '32x32' },
-    { rel: 'icon', url: '/favicon-192.png', type: 'image/png', sizes: '192x192' },
-    { rel: 'icon', url: '/favicon-512.png', type: 'image/png', sizes: '512x512' },
-  ]
-}
+export const size = { width: 32, height: 32 }
+export const contentType = 'image/png'
 
-// Fallback dinámico si faltan los PNG en /public
 export default function Icon() {
   return new ImageResponse(
     (
-      <div
-        style={{
-          width: '100%',
-          height: '100%',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          fontSize: 20,
-          background: '#21396f',
-          color: 'white',
-        }}
-      >
-        VS
-      </div>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+        <rect width="100" height="100" rx="20" />
+        <text x="50" y="60" textAnchor="middle" fontSize="56" fontFamily="Arial">V</text>
+      </svg>
     ),
-    { width: 32, height: 32 }
+    { ...size }
   )
 }


### PR DESCRIPTION
## Summary
- simplify app icon to generate SVG-based image response

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck` (fails: cannot find modules)
- `npm run build` (fails: module not found)


------
https://chatgpt.com/codex/tasks/task_e_68990c4f8f848330adabbcd8c1342087