### PR TITLE
ci: fix typecheck script name and clear npm proxy config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,17 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      - name: Clear npm proxy config
+        run: |
+          npm config delete proxy || true
+          npm config delete http-proxy || true
+          npm config delete https-proxy || true
       - name: Install
         run: npm ci
       - name: Lint (no bloqueante)
         run: npm run lint || true
       - name: Typecheck
-        run: npm run typecheck
+        run: npm run type-check
       - name: Build
         run: npm run build
       - name: Verificación de arquitectura

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "verify:repo": "node scripts/verify-architecture.mjs",
     "type-check": "tsc --noEmit",
     "ci:verify": "npm run lint || true && npm run type-check && next build && npm run verify:repo",
-    "test": "echo 'OK: no tests yet' && exit 0"
+    "test": "echo 'OK: no tests yet' && exit 0",
+    "typecheck": "npm run type-check"
   },
   "dependencies": {
     "next": "^15.4.2",


### PR DESCRIPTION
## Summary
- fix typecheck script naming in CI workflow
- add alias `typecheck` script
- clear npm proxy config before install in CI

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689ca525b4e48330bdd77a9d31d44418